### PR TITLE
refactor: Remove tenant_id from users table

### DIFF
--- a/auth/postgres_store.go
+++ b/auth/postgres_store.go
@@ -47,20 +47,14 @@ func (s *PostgresIdentityStore) ResolveOrProvisionUser(ctx context.Context, iden
 		IdentifierSubject: identity.Subject,
 	})
 	if err == nil {
-		// User exists - ensure they have at least one membership
+		// User exists - verify they have at least one membership
 		memberships, listErr := s.ListMemberships(ctx, user.ID)
 		if listErr != nil {
-			return UserRef{}, listErr
+			return UserRef{}, fmt.Errorf("failed to list memberships: %w", listErr)
 		}
 		if len(memberships) == 0 {
-			// Use fallback tenant_id from user record
-			if !user.TenantID.Valid {
-				return UserRef{}, fmt.Errorf("user must belong to at least one tenant")
-			}
-			tenantID := user.TenantID.Bytes
-			if _, createErr := s.createMembership(ctx, user.ID, tenantID, RoleMember); createErr != nil {
-				return UserRef{}, createErr
-			}
+			// Data integrity issue - user should have at least one membership
+			return UserRef{}, fmt.Errorf("user %s has no tenant memberships (data integrity issue)", user.ID)
 		}
 		return UserRef{
 			UserID:  user.ID,
@@ -93,7 +87,6 @@ func (s *PostgresIdentityStore) ResolveOrProvisionUser(ctx context.Context, iden
 	now := time.Now()
 	created, err := s.queries.InsertUser(ctx, db.InsertUserParams{
 		ID:                userID,
-		TenantID:          pgtype.UUID{Bytes: tenantID, Valid: true},
 		Email:             identity.Email,
 		EmailVerified:     identity.EmailVerified,
 		Username:          pgtype.Text{String: username, Valid: username != ""},
@@ -115,7 +108,7 @@ func (s *PostgresIdentityStore) ResolveOrProvisionUser(ctx context.Context, iden
 		return UserRef{}, fmt.Errorf("failed to list memberships for created user: %w", err)
 	}
 	if len(memberships) == 0 {
-		return UserRef{}, fmt.Errorf("user must belong to at least one tenant")
+		return UserRef{}, fmt.Errorf("failed to verify membership creation")
 	}
 
 	return UserRef{

--- a/internal/db/auth.sql.go
+++ b/internal/db/auth.sql.go
@@ -71,8 +71,7 @@ const getUserByIdentifier = `-- name: GetUserByIdentifier :one
 SELECT
     id,
     issuer,
-    identifier_subject,
-    tenant_id
+    identifier_subject
 FROM users
 WHERE issuer = $1 AND identifier_subject = $2
 `
@@ -83,21 +82,15 @@ type GetUserByIdentifierParams struct {
 }
 
 type GetUserByIdentifierRow struct {
-	ID                uuid.UUID   `json:"id"`
-	Issuer            string      `json:"issuer"`
-	IdentifierSubject string      `json:"identifier_subject"`
-	TenantID          pgtype.UUID `json:"tenant_id"`
+	ID                uuid.UUID `json:"id"`
+	Issuer            string    `json:"issuer"`
+	IdentifierSubject string    `json:"identifier_subject"`
 }
 
 func (q *Queries) GetUserByIdentifier(ctx context.Context, arg GetUserByIdentifierParams) (GetUserByIdentifierRow, error) {
 	row := q.db.QueryRow(ctx, getUserByIdentifier, arg.Issuer, arg.IdentifierSubject)
 	var i GetUserByIdentifierRow
-	err := row.Scan(
-		&i.ID,
-		&i.Issuer,
-		&i.IdentifierSubject,
-		&i.TenantID,
-	)
+	err := row.Scan(&i.ID, &i.Issuer, &i.IdentifierSubject)
 	return i, err
 }
 
@@ -119,7 +112,6 @@ func (q *Queries) InsertTenant(ctx context.Context, arg InsertTenantParams) erro
 const insertUser = `-- name: InsertUser :one
 INSERT INTO users (
     id,
-    tenant_id,
     email,
     email_verified,
     username,
@@ -128,14 +120,13 @@ INSERT INTO users (
     identifier_subject,
     last_login_at
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8, $9
+    $1, $2, $3, $4, $5, $6, $7, $8
 )
 RETURNING id, issuer, identifier_subject
 `
 
 type InsertUserParams struct {
 	ID                uuid.UUID          `json:"id"`
-	TenantID          pgtype.UUID        `json:"tenant_id"`
 	Email             string             `json:"email"`
 	EmailVerified     bool               `json:"email_verified"`
 	Username          pgtype.Text        `json:"username"`
@@ -154,7 +145,6 @@ type InsertUserRow struct {
 func (q *Queries) InsertUser(ctx context.Context, arg InsertUserParams) (InsertUserRow, error) {
 	row := q.db.QueryRow(ctx, insertUser,
 		arg.ID,
-		arg.TenantID,
 		arg.Email,
 		arg.EmailVerified,
 		arg.Username,

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -34,7 +34,6 @@ type TenantMembership struct {
 
 type User struct {
 	ID                uuid.UUID          `json:"id"`
-	TenantID          pgtype.UUID        `json:"tenant_id"`
 	Email             string             `json:"email"`
 	EmailVerified     bool               `json:"email_verified"`
 	Username          pgtype.Text        `json:"username"`

--- a/migrations/auth/20260330043700_remove_tenant_id_from_users.sql
+++ b/migrations/auth/20260330043700_remove_tenant_id_from_users.sql
@@ -1,0 +1,36 @@
+-- +goose Up
+-- +goose StatementBegin
+-- Remove tenant_id from users table
+-- User-tenant relationships are now exclusively managed via tenant_memberships
+
+-- First, create memberships for any users that don't have one but have a tenant_id
+INSERT INTO tenant_memberships (user_id, tenant_id, role, created_at, updated_at)
+SELECT id, tenant_id, 'member', NOW(), NOW()
+FROM users
+WHERE tenant_id IS NOT NULL
+AND NOT EXISTS (
+    SELECT 1 FROM tenant_memberships tm WHERE tm.user_id = users.id
+);
+
+-- Now drop the tenant_id column
+ALTER TABLE users DROP COLUMN tenant_id;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+-- Re-add tenant_id column
+ALTER TABLE users ADD COLUMN tenant_id UUID REFERENCES tenants(tenant_id) ON DELETE RESTRICT;
+
+-- Migrate back: set tenant_id to the first membership's tenant
+UPDATE users u
+SET tenant_id = (
+    SELECT tm.tenant_id 
+    FROM tenant_memberships tm 
+    WHERE tm.user_id = u.id 
+    ORDER BY tm.created_at 
+    LIMIT 1
+)
+WHERE EXISTS (
+    SELECT 1 FROM tenant_memberships tm WHERE tm.user_id = u.id
+);
+-- +goose StatementEnd

--- a/queries/auth.sql
+++ b/queries/auth.sql
@@ -2,15 +2,13 @@
 SELECT
     id,
     issuer,
-    identifier_subject,
-    tenant_id
+    identifier_subject
 FROM users
 WHERE issuer = $1 AND identifier_subject = $2;
 
 -- name: InsertUser :one
 INSERT INTO users (
     id,
-    tenant_id,
     email,
     email_verified,
     username,
@@ -19,7 +17,7 @@ INSERT INTO users (
     identifier_subject,
     last_login_at
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8, $9
+    $1, $2, $3, $4, $5, $6, $7, $8
 )
 RETURNING id, issuer, identifier_subject;
 


### PR DESCRIPTION
## Summary

Remove the \`tenant_id\` column from the \`users\` table. User-tenant relationships are now exclusively managed via the \`tenant_memberships\` table.

## Motivation

The previous design had a conceptual conflict:
- \`users.tenant_id\` implied a user belongs to a single tenant
- \`tenant_memberships\` allows users to belong to multiple tenants

This created confusion about which was the source of truth and led to fallback logic that masked data integrity issues.

## Changes

### Database Migration
- \`migrations/auth/20260330043700_remove_tenant_id_from_users.sql\`
  - Creates memberships for any users that have \`tenant_id\` but no membership record
  - Drops the \`tenant_id\` column from users

### Code Changes
- Updated \`queries/auth.sql\` to remove tenant_id from user queries
- Regenerated sqlc code (\`internal/db/\`)
- Updated \`auth/postgres_store.go\`:
  - Removed fallback logic that used \`user.TenantID\`
  - Users without memberships now get a clear error (data integrity issue)
  - Removed TenantID from InsertUserParams

## Behavior Changes

**Before:** A user without memberships would fall back to \`users.tenant_id\` and auto-create a membership.

**After:** A user without memberships is treated as a data integrity error (should not happen with normal code paths).

## Testing

- Unit tests pass
- Integration tests require Docker (not run locally)

## Migration Safety

The migration is safe to run:
1. It first creates missing memberships from existing tenant_id values
2. Then drops the column
3. Down migration re-adds the column and populates from first membership