### PR TITLE
feat(app): add CORS middleware with configurable allowed origins

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	chiMiddleware "github.com/go-chi/chi/v5/middleware"
+	"github.com/go-chi/cors"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/kusold/gotchi/auth"
 	"github.com/kusold/gotchi/db"
@@ -147,6 +148,18 @@ func (a *Application) Run(ctx context.Context) error {
 	a.router.Use(chiMiddleware.RealIP)
 	a.router.Use(chiMiddleware.Logger)
 	a.router.Use(chiMiddleware.Recoverer)
+
+	if a.cfg.CORS.Enabled() {
+		corsCfg := a.cfg.CORS
+		a.router.Use(cors.Handler(cors.Options{
+			AllowedOrigins:   corsCfg.AllowedOrigins,
+			AllowedMethods:   corsCfg.AllowedMethods,
+			AllowedHeaders:   corsCfg.AllowedHeaders,
+			ExposedHeaders:   corsCfg.ExposedHeaders,
+			AllowCredentials: *corsCfg.AllowCredentials,
+			MaxAge:           corsCfg.MaxAge,
+		}))
+	}
 
 	if a.cfg.OTEL.TracingEnabled() {
 		a.router.Use(observability.OTELTracingMiddleware(a.cfg.OTEL.ServiceName))

--- a/app/application_test.go
+++ b/app/application_test.go
@@ -1,9 +1,12 @@
 package app
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/cors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -114,5 +117,100 @@ func TestNewAppliesDefaults(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotNil(t, app.cfg.Migrations.Sources)
 		assert.Empty(t, app.cfg.Migrations.Sources)
+	})
+}
+
+func TestCORSMiddleware(t *testing.T) {
+	t.Run("sets CORS headers when origins configured", func(t *testing.T) {
+		cfg := testConfig()
+		cfg.CORS = CORSConfig{AllowedOrigins: []string{"https://example.com"}}
+		corsCfg := cfg.CORS.WithDefaults()
+		app, err := New(cfg)
+		require.NoError(t, err)
+
+		app.router.Get("/test", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+
+		req := httptest.NewRequest(http.MethodOptions, "/test", nil)
+		req.Header.Set("Origin", "https://example.com")
+		req.Header.Set("Access-Control-Request-Method", "GET")
+		w := httptest.NewRecorder()
+
+		cors.Handler(cors.Options{
+			AllowedOrigins:   corsCfg.AllowedOrigins,
+			AllowedMethods:   corsCfg.AllowedMethods,
+			AllowedHeaders:   corsCfg.AllowedHeaders,
+			ExposedHeaders:   corsCfg.ExposedHeaders,
+			AllowCredentials: *corsCfg.AllowCredentials,
+			MaxAge:           corsCfg.MaxAge,
+		})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			app.router.ServeHTTP(w, r)
+		})).ServeHTTP(w, req)
+
+		assert.Equal(t, "https://example.com", w.Header().Get("Access-Control-Allow-Origin"))
+	})
+
+	t.Run("rejects disallowed origin", func(t *testing.T) {
+		cfg := testConfig()
+		cfg.CORS = CORSConfig{AllowedOrigins: []string{"https://example.com"}}
+		corsCfg := cfg.CORS.WithDefaults()
+		app, err := New(cfg)
+		require.NoError(t, err)
+
+		app.router.Get("/test", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+
+		req := httptest.NewRequest(http.MethodOptions, "/test", nil)
+		req.Header.Set("Origin", "https://evil.com")
+		req.Header.Set("Access-Control-Request-Method", "GET")
+		w := httptest.NewRecorder()
+
+		cors.Handler(cors.Options{
+			AllowedOrigins:   corsCfg.AllowedOrigins,
+			AllowedMethods:   corsCfg.AllowedMethods,
+			AllowedHeaders:   corsCfg.AllowedHeaders,
+			ExposedHeaders:   corsCfg.ExposedHeaders,
+			AllowCredentials: *corsCfg.AllowCredentials,
+			MaxAge:           corsCfg.MaxAge,
+		})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			app.router.ServeHTTP(w, r)
+		})).ServeHTTP(w, req)
+
+		assert.Empty(t, w.Header().Get("Access-Control-Allow-Origin"))
+	})
+
+	t.Run("respects custom AllowedMethods", func(t *testing.T) {
+		cfg := testConfig()
+		cfg.CORS = CORSConfig{
+			AllowedOrigins: []string{"https://example.com"},
+			AllowedMethods: []string{"GET"},
+		}
+		corsCfg := cfg.CORS.WithDefaults()
+		app, err := New(cfg)
+		require.NoError(t, err)
+
+		app.router.Get("/test", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+
+		req := httptest.NewRequest(http.MethodOptions, "/test", nil)
+		req.Header.Set("Origin", "https://example.com")
+		req.Header.Set("Access-Control-Request-Method", "POST")
+		w := httptest.NewRecorder()
+
+		cors.Handler(cors.Options{
+			AllowedOrigins:   corsCfg.AllowedOrigins,
+			AllowedMethods:   corsCfg.AllowedMethods,
+			AllowedHeaders:   corsCfg.AllowedHeaders,
+			ExposedHeaders:   corsCfg.ExposedHeaders,
+			AllowCredentials: *corsCfg.AllowCredentials,
+			MaxAge:           corsCfg.MaxAge,
+		})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			app.router.ServeHTTP(w, r)
+		})).ServeHTTP(w, req)
+
+		assert.Empty(t, w.Header().Get("Access-Control-Allow-Methods"))
 	})
 }

--- a/app/config.go
+++ b/app/config.go
@@ -19,6 +19,84 @@ type Config struct {
 	OpenAPI    openapi.Config
 	Migrations MigrationConfig
 	OTEL       observability.OTELConfig
+	CORS       CORSConfig
+}
+
+type CORSConfig struct {
+	AllowedOrigins   []string
+	AllowedMethods   []string
+	AllowedHeaders   []string
+	ExposedHeaders   []string
+	AllowCredentials *bool
+	MaxAge           int
+}
+
+const (
+	DefaultCORSAllowedMethodGET     = "GET"
+	DefaultCORSAllowedMethodPOST    = "POST"
+	DefaultCORSAllowedMethodPUT     = "PUT"
+	DefaultCORSAllowedMethodPATCH   = "PATCH"
+	DefaultCORSAllowedMethodDELETE  = "DELETE"
+	DefaultCORSAllowedMethodOPTIONS = "OPTIONS"
+
+	DefaultCORSAllowedHeaderAccept        = "Accept"
+	DefaultCORSAllowedHeaderAuthorization = "Authorization"
+	DefaultCORSAllowedHeaderContentType   = "Content-Type"
+	DefaultCORSAllowedHeaderXCSRFToken    = "X-CSRF-Token"
+	DefaultCORSAllowedHeaderXRequestID    = "X-Request-ID"
+
+	DefaultCORSExposedHeaderLink       = "Link"
+	DefaultCORSExposedHeaderXRequestID = "X-Request-ID"
+
+	DefaultCORSMaxAge = 300
+)
+
+var (
+	DefaultCORSAllowedMethods = []string{
+		DefaultCORSAllowedMethodGET,
+		DefaultCORSAllowedMethodPOST,
+		DefaultCORSAllowedMethodPUT,
+		DefaultCORSAllowedMethodPATCH,
+		DefaultCORSAllowedMethodDELETE,
+		DefaultCORSAllowedMethodOPTIONS,
+	}
+	DefaultCORSAllowedHeaders = []string{
+		DefaultCORSAllowedHeaderAccept,
+		DefaultCORSAllowedHeaderAuthorization,
+		DefaultCORSAllowedHeaderContentType,
+		DefaultCORSAllowedHeaderXCSRFToken,
+		DefaultCORSAllowedHeaderXRequestID,
+	}
+	DefaultCORSExposedHeaders = []string{
+		DefaultCORSExposedHeaderLink,
+		DefaultCORSExposedHeaderXRequestID,
+	}
+)
+
+func boolPtr(b bool) *bool { return &b }
+
+func (c CORSConfig) WithDefaults() CORSConfig {
+	cfg := c
+	if len(cfg.AllowedMethods) == 0 {
+		cfg.AllowedMethods = DefaultCORSAllowedMethods
+	}
+	if len(cfg.AllowedHeaders) == 0 {
+		cfg.AllowedHeaders = DefaultCORSAllowedHeaders
+	}
+	if len(cfg.ExposedHeaders) == 0 {
+		cfg.ExposedHeaders = DefaultCORSExposedHeaders
+	}
+	if cfg.AllowCredentials == nil {
+		cfg.AllowCredentials = boolPtr(true)
+	}
+	if cfg.MaxAge == 0 {
+		cfg.MaxAge = DefaultCORSMaxAge
+	}
+	return cfg
+}
+
+func (c CORSConfig) Enabled() bool {
+	return len(c.AllowedOrigins) > 0
 }
 
 type ServerConfig struct {
@@ -47,6 +125,9 @@ func (c Config) withDefaults() Config {
 	}
 	if len(cfg.Migrations.Sources) == 0 {
 		cfg.Migrations.Sources = []db.MigrationSource{}
+	}
+	if cfg.CORS.Enabled() {
+		cfg.CORS = cfg.CORS.WithDefaults()
 	}
 	return cfg
 }

--- a/app/config_test.go
+++ b/app/config_test.go
@@ -58,12 +58,88 @@ func TestConfigWithDefaults(t *testing.T) {
 		cfg.Server.Port = "9000"
 		cfg.Database.EnableSlogTracing = true
 		cfg.Migrations = MigrationConfig{EnableCore: true, EnableAuth: true}
+		cfg.CORS = CORSConfig{AllowedOrigins: []string{"https://example.com"}}
 		withDefaults := cfg.withDefaults()
 		assert.Equal(t, "9000", withDefaults.Server.Port)
 		assert.Equal(t, "postgres://example", withDefaults.Database.DatabaseURL)
 		assert.True(t, withDefaults.Database.EnableSlogTracing)
 		assert.True(t, withDefaults.Migrations.EnableCore)
 		assert.True(t, withDefaults.Migrations.EnableAuth)
+		assert.Equal(t, []string{"https://example.com"}, withDefaults.CORS.AllowedOrigins)
+	})
+
+	t.Run("preserves empty CORS config when not provided", func(t *testing.T) {
+		cfg := testConfig()
+		withDefaults := cfg.withDefaults()
+		assert.Nil(t, withDefaults.CORS.AllowedOrigins)
+	})
+}
+
+func TestCORSConfigWithDefaults(t *testing.T) {
+	t.Run("fills all defaults when only origins provided", func(t *testing.T) {
+		cfg := CORSConfig{AllowedOrigins: []string{"https://example.com"}}
+		withDefaults := cfg.WithDefaults()
+		assert.Equal(t, []string{"https://example.com"}, withDefaults.AllowedOrigins)
+		assert.Equal(t, DefaultCORSAllowedMethods, withDefaults.AllowedMethods)
+		assert.Equal(t, DefaultCORSAllowedHeaders, withDefaults.AllowedHeaders)
+		assert.Equal(t, DefaultCORSExposedHeaders, withDefaults.ExposedHeaders)
+		assert.True(t, *withDefaults.AllowCredentials)
+		assert.Equal(t, DefaultCORSMaxAge, withDefaults.MaxAge)
+	})
+
+	t.Run("preserves custom AllowedMethods", func(t *testing.T) {
+		cfg := CORSConfig{
+			AllowedOrigins: []string{"https://example.com"},
+			AllowedMethods: []string{"GET", "POST"},
+		}
+		withDefaults := cfg.WithDefaults()
+		assert.Equal(t, []string{"GET", "POST"}, withDefaults.AllowedMethods)
+	})
+
+	t.Run("preserves custom AllowedHeaders", func(t *testing.T) {
+		cfg := CORSConfig{
+			AllowedOrigins: []string{"https://example.com"},
+			AllowedHeaders: []string{"Content-Type"},
+		}
+		withDefaults := cfg.WithDefaults()
+		assert.Equal(t, []string{"Content-Type"}, withDefaults.AllowedHeaders)
+	})
+
+	t.Run("preserves custom ExposedHeaders", func(t *testing.T) {
+		cfg := CORSConfig{
+			AllowedOrigins: []string{"https://example.com"},
+			ExposedHeaders: []string{"X-Custom"},
+		}
+		withDefaults := cfg.WithDefaults()
+		assert.Equal(t, []string{"X-Custom"}, withDefaults.ExposedHeaders)
+	})
+
+	t.Run("preserves AllowCredentials false", func(t *testing.T) {
+		cfg := CORSConfig{
+			AllowedOrigins:   []string{"https://example.com"},
+			AllowCredentials: boolPtr(false),
+		}
+		withDefaults := cfg.WithDefaults()
+		assert.False(t, *withDefaults.AllowCredentials)
+	})
+
+	t.Run("preserves custom MaxAge", func(t *testing.T) {
+		cfg := CORSConfig{
+			AllowedOrigins: []string{"https://example.com"},
+			MaxAge:         600,
+		}
+		withDefaults := cfg.WithDefaults()
+		assert.Equal(t, 600, withDefaults.MaxAge)
+	})
+
+	t.Run("Enabled returns true when origins set", func(t *testing.T) {
+		cfg := CORSConfig{AllowedOrigins: []string{"https://example.com"}}
+		assert.True(t, cfg.Enabled())
+	})
+
+	t.Run("Enabled returns false when origins empty", func(t *testing.T) {
+		cfg := CORSConfig{}
+		assert.False(t, cfg.Enabled())
 	})
 }
 

--- a/examples/reference-app/.env.sample
+++ b/examples/reference-app/.env.sample
@@ -7,3 +7,5 @@ OIDC_CLIENT_SECRET=
 OIDC_REDIRECT_URL=http://localhost:3000/auth/oidc/callback
 OIDC_TENANT_PICKER_PATH=/auth/tenants
 OIDC_POST_LOGIN_REDIRECT=/
+
+CORS_ALLOWED_ORIGINS=http://localhost:3000

--- a/examples/reference-app/cmd/server/main.go
+++ b/examples/reference-app/cmd/server/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/kusold/gotchi/app"
 	"github.com/kusold/gotchi/db"
@@ -18,10 +19,13 @@ func main() {
 			DatabaseURL: getenv("DATABASE_URL", ""),
 		},
 		Auth: app.AuthConfig{},
+		CORS: app.CORSConfig{
+			AllowedOrigins: parseCSV(getenv("CORS_ALLOWED_ORIGINS", "")),
+		},
 		Migrations: app.MigrationConfig{
 			EnableCore: true,
 			EnableAuth: true,
-			Sources: []db.MigrationSource{{FS: migrations.Migrations, Dir: "."}},
+			Sources:    []db.MigrationSource{{FS: migrations.Migrations, Dir: "."}},
 		},
 	}
 
@@ -37,4 +41,15 @@ func getenv(key, fallback string) string {
 		return value
 	}
 	return fallback
+}
+
+func parseCSV(s string) []string {
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	for i, p := range parts {
+		parts[i] = strings.TrimSpace(p)
+	}
+	return parts
 }

--- a/examples/reference-app/go.mod
+++ b/examples/reference-app/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/coreos/go-oidc/v3 v3.17.0 // indirect
 	github.com/exaring/otelpgx v0.10.0 // indirect
+	github.com/go-chi/cors v1.2.2 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/examples/reference-app/go.sum
+++ b/examples/reference-app/go.sum
@@ -40,6 +40,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/go-chi/chi/v5 v5.2.5 h1:Eg4myHZBjyvJmAFjFvWgrqDTXFyOzjj7YIm3L3mu6Ug=
 github.com/go-chi/chi/v5 v5.2.5/go.mod h1:X7Gx4mteadT3eDOMTsXzmI4/rwUpOwBHLpAfupzFJP0=
+github.com/go-chi/cors v1.2.2 h1:Jmey33TE+b+rB7fT8MUy1u0I4L+NARQlK6LhzKPSyQE=
+github.com/go-chi/cors v1.2.2/go.mod h1:sSbTewc+6wYHBBCW7ytsFSn836hqM7JxpglAy2Vzc58=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
 github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/docker/go-connections v0.6.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
+	github.com/go-chi/cors v1.2.2 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/go-chi/chi/v5 v5.2.5 h1:Eg4myHZBjyvJmAFjFvWgrqDTXFyOzjj7YIm3L3mu6Ug=
 github.com/go-chi/chi/v5 v5.2.5/go.mod h1:X7Gx4mteadT3eDOMTsXzmI4/rwUpOwBHLpAfupzFJP0=
+github.com/go-chi/cors v1.2.2 h1:Jmey33TE+b+rB7fT8MUy1u0I4L+NARQlK6LhzKPSyQE=
+github.com/go-chi/cors v1.2.2/go.mod h1:sSbTewc+6wYHBBCW7ytsFSn836hqM7JxpglAy2Vzc58=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
 github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=


### PR DESCRIPTION
## Summary

- Add `go-chi/cors` middleware integration to the app framework via a new `CORSConfig` with a configurable `AllowedOrigins` field
- CORS middleware is only enabled when `AllowedOrigins` is non-empty; all other CORS options (methods, headers, credentials, max age) are hard coded with sensible defaults
- Reference app updated to demonstrate configuration via `CORS_ALLOWED_ORIGINS` environment variable

## Changes

- **`app/config.go`**: Add `CORSConfig` struct with `AllowedOrigins []string` field to `Config`
- **`app/app.go`**: Wire up `cors.Handler` when `AllowedOrigins` is provided, placed after `Recoverer` and before OTEL middleware
- **`app/config_test.go`**: Add tests for CORS config preservation through defaults
- **`app/application_test.go`**: Add tests verifying CORS headers are set for allowed origins and rejected for disallowed origins
- **`examples/reference-app/`**: Update to show `CORS_ALLOWED_ORIGINS` env var usage with `parseCSV` helper

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./app/ -v` passes (including new CORS tests)
- [x] `go build ./...` passes