### PR TITLE
docs: add comprehensive godoc documentation for all public packages

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1,3 +1,70 @@
+// Package app provides a multi-tenant web application framework built on top of
+// the Chi router. It orchestrates database connections, schema migrations,
+// session management, OpenID Connect authentication, OpenAPI specification
+// serving, and OpenTelemetry observability into a single cohesive Application
+// type.
+//
+// The central type is [Application], which is created with [New] using the
+// functional options pattern and started with [Application.Run]. An Application
+// is composed of zero or more [Module] implementations that register routes on
+// the Chi router and receive shared [Dependencies] (database pool, session
+// manager, auth handler, etc.).
+//
+// # Quick Start
+//
+// Create a minimal application with a database URL and a custom module:
+//
+//	application, err := app.New(
+//	    app.WithDatabase("postgres://user:pass@localhost/mydb"),
+//	    app.WithCoreMigrations(),
+//	    app.WithMigrations(db.MigrationSource{FS: myMigrationFS, Dir: "migrations"}),
+//	    app.WithModule(app.ModuleFunc(func(r chi.Router, deps app.Dependencies) error {
+//	        r.Get("/health", func(w http.ResponseWriter, _ *http.Request) {
+//	            w.WriteHeader(http.StatusOK)
+//	        })
+//	        return nil
+//	    })),
+//	)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//
+//	if err := application.Run(context.Background()); err != nil {
+//	    log.Fatal(err)
+//	}
+//
+// # Options
+//
+// Applications are configured using [Option] functions passed to [New].
+// Required options include [WithDatabase] (or [WithDatabaseConfig]). All other
+// options are optional and have sensible defaults:
+//
+//   - [WithPort] — HTTP server port (default "3000")
+//   - [WithAuth] — enables OIDC authentication (auto-enables sessions)
+//   - [WithSessions] — explicit session configuration
+//   - [WithOTEL] — OpenTelemetry tracing and metrics
+//   - [WithCORS] / [WithCORSConfig] — cross-origin resource sharing
+//   - [WithCoreMigrations] / [WithAuthMigrations] / [WithMigrations] — database schemas
+//   - [WithMiddleware] / [WithNoDefaultMiddleware] — HTTP middleware chain
+//   - [WithModule] — registers application modules
+//   - [WithClock] / [WithLogger] — testing and observability overrides
+//
+// # Modules
+//
+// A [Module] is any type that implements the single-method interface:
+//
+//	type Module interface {
+//	    Register(r chi.Router, deps Dependencies) error
+//	}
+//
+// For convenience, [ModuleFunc] wraps a plain function so it satisfies the
+// [Module] interface, similar to http.HandlerFunc.
+//
+// # Validation and Defaults
+//
+// Options are validated during [New]. The builder applies defaults for
+// unspecified optional fields (e.g., port defaults to "3000", logger defaults to
+// slog.Default). See [builder.applyDefaults] for the full list of defaults.
 package app
 
 import (
@@ -22,13 +89,16 @@ import (
 
 // Clock abstracts time for testability.
 type Clock interface {
+	// Now returns the current time according to the clock implementation.
 	Now() time.Time
 }
 
+// realClock is the production Clock implementation that delegates to time.Now.
 type realClock struct{}
 
 const defaultOTELShutdownTimeout = 5 * time.Second
 
+// Now returns the current local time.
 func (realClock) Now() time.Time {
 	return time.Now()
 }
@@ -36,26 +106,50 @@ func (realClock) Now() time.Time {
 // Module defines a self-contained unit of routes and behavior
 // that is registered with shared dependencies.
 type Module interface {
+	// Register wires the module into the Chi router using the provided
+	// Dependencies. It is called once during [Application.Run].
 	Register(r chi.Router, deps Dependencies) error
 }
 
 // ModuleFunc adapts an ordinary function to the Module interface.
 type ModuleFunc func(r chi.Router, deps Dependencies) error
 
+// Register calls f(r, deps), satisfying the [Module] interface.
 func (f ModuleFunc) Register(r chi.Router, deps Dependencies) error {
 	return f(r, deps)
 }
 
 // Dependencies holds the initialized services available to modules.
 type Dependencies struct {
-	DB            *db.Manager
-	Pool          *pgxpool.Pool
-	Session       *session.Manager
-	Auth          *auth.OIDCHandler
+	// DB is the database manager responsible for connection pooling and
+	// running migrations.
+	DB *db.Manager
+
+	// Pool is the underlying pgxpool connection pool. Use this for direct
+	// database queries within modules.
+	Pool *pgxpool.Pool
+
+	// Session provides cookie- or header-based session management backed by
+	// PostgreSQL.
+	Session *session.Manager
+
+	// Auth is the OpenID Connect handler, or nil when OIDC is disabled in
+	// the configuration.
+	Auth *auth.OIDCHandler
+
+	// IdentityStore provides user identity lookup and persistence. It is
+	// non-nil only when OIDC authentication is enabled.
 	IdentityStore auth.IdentityStore
-	OpenAPI       openapi.Config
-	Logger        *slog.Logger
-	Clock         Clock
+
+	// OpenAPI holds the configuration for serving OpenAPI documentation
+	// endpoints.
+	OpenAPI openapi.Config
+
+	// Logger is the application-wide structured logger (slog).
+	Logger *slog.Logger
+
+	// Clock provides the current time and can be replaced in tests.
+	Clock Clock
 }
 
 // Application is the main entry point. Construct one with New and

--- a/auth/config.go
+++ b/auth/config.go
@@ -1,25 +1,54 @@
 package auth
 
+// Config holds all configuration for OIDC authentication. Path fields default
+// to the corresponding Default* constants when empty. Use [Config.WithDefaults]
+// to populate defaults explicitly.
 type Config struct {
-	Enabled      bool
-	IssuerURL    string
-	ClientID     string
+	// Enabled controls whether OIDC authentication is active.
+	Enabled bool
+	// IssuerURL is the OIDC provider's issuer URL (e.g. "https://accounts.google.com").
+	// Required when Enabled is true.
+	IssuerURL string
+	// ClientID is the OAuth2 client ID registered with the OIDC provider.
+	// Required when Enabled is true.
+	ClientID string
+	// ClientSecret is the OAuth2 client secret registered with the OIDC provider.
+	// Required when Enabled is true.
 	ClientSecret string
-	RedirectURL  string
+	// RedirectURL is the callback URL that the OIDC provider redirects to after
+	// authentication (e.g. "https://myapp.com/oidc/callback"). Required when
+	// Enabled is true.
+	RedirectURL string
 
-	LoginPath         string
+	// LoginPath is the URL path for the login page. Defaults to [DefaultLoginPath].
+	LoginPath string
+	// PostLoginRedirect is the URL to redirect to after successful login.
+	// Defaults to [DefaultPostLoginRedirect].
 	PostLoginRedirect string
-	TenantPickerPath  string
-	SessionKey        string
+	// TenantPickerPath is the URL path for the tenant selection UI.
+	// Defaults to [DefaultTenantPickerPath].
+	TenantPickerPath string
+	// SessionKey is the key used to store claims in the session.
+	// Defaults to [DefaultSessionKey].
+	SessionKey string
 
-	AuthorizePath    string
-	CallbackPath     string
-	TenantsPath      string
+	// AuthorizePath is the URL path that initiates the OIDC authorize redirect.
+	// Defaults to [DefaultAuthorizePath].
+	AuthorizePath string
+	// CallbackPath is the URL path that handles the OIDC callback.
+	// Defaults to [DefaultCallbackPath].
+	CallbackPath string
+	// TenantsPath is the URL path for the API endpoint listing a user's tenants.
+	// Defaults to [DefaultTenantsPath].
+	TenantsPath string
+	// TenantSelectPath is the URL path for the API endpoint to select a tenant.
+	// Defaults to [DefaultTenantSelectPath].
 	TenantSelectPath string
-	StateCookieName  string
+	// StateCookieName is the name of the cookie holding the OIDC state parameter.
+	// Defaults to [DefaultStateCookieName].
+	StateCookieName string
 	// CookieSecure controls the Secure flag on the state cookie.
-	// Defaults to true for security. Set to false only for development
-	// or when behind a TLS-terminating proxy that handles HTTPS.
+	// Defaults to true for security. Set to false only for local development.
 	CookieSecure *bool
 }
 
@@ -59,6 +88,8 @@ func (c Config) withDefaults() Config {
 	return cfg
 }
 
+// WithDefaults returns a copy of Config with empty fields populated by their
+// default values.
 func (c Config) WithDefaults() Config {
 	return c.withDefaults()
 }

--- a/auth/context.go
+++ b/auth/context.go
@@ -8,14 +8,19 @@ import (
 
 type claimsContextKey struct{}
 
+// ClaimsContextValue is a placeholder type for claims context values.
 type ClaimsContextValue struct{}
 
 var claimsContextToken = claimsContextKey{}
 
+// WithSessionClaims returns a new context with the given SessionClaims attached.
 func WithSessionClaims(ctx context.Context, claims SessionClaims) context.Context {
 	return context.WithValue(ctx, claimsContextToken, claims)
 }
 
+// SessionClaimsFromContext extracts SessionClaims from the context. Returns
+// the claims and true if present, or a zero-value SessionClaims and false
+// otherwise.
 func SessionClaimsFromContext(ctx context.Context) (SessionClaims, bool) {
 	claims, ok := ctx.Value(claimsContextToken).(SessionClaims)
 	if !ok {

--- a/auth/handler.go
+++ b/auth/handler.go
@@ -15,6 +15,10 @@ import (
 	"github.com/kusold/gotchi/session"
 )
 
+// OIDCHandler manages the OpenID Connect authentication flow including
+// authorization redirects, token exchange, user provisioning, and tenant
+// selection. Create one with [NewOIDCHandler] and register its routes with
+// [OIDCHandler.RegisterRoutes].
 type OIDCHandler struct {
 	cfg     Config
 	oidc    *OIDCAuthenticator
@@ -22,6 +26,12 @@ type OIDCHandler struct {
 	store   IdentityStore
 }
 
+// NewOIDCHandler creates a new OIDCHandler with the given configuration,
+// session manager, and identity store. It initializes the OIDC authenticator
+// by discovering the provider's endpoints from the IssuerURL.
+//
+// Returns an error if the identity store is nil or if the OIDC provider
+// cannot be reached.
 func NewOIDCHandler(cfg Config, sessionManager *session.Manager, store IdentityStore) (*OIDCHandler, error) {
 	conf := cfg.withDefaults()
 	if store == nil {
@@ -34,6 +44,9 @@ func NewOIDCHandler(cfg Config, sessionManager *session.Manager, store IdentityS
 	return NewOIDCHandlerWithAuthenticator(conf, authenticator, sessionManager, store), nil
 }
 
+// NewOIDCHandlerWithAuthenticator creates a new OIDCHandler with a
+// pre-configured [OIDCAuthenticator]. This is useful for testing or when
+// the authenticator needs custom configuration.
 func NewOIDCHandlerWithAuthenticator(cfg Config, authenticator *OIDCAuthenticator, sessionManager *session.Manager, store IdentityStore) *OIDCHandler {
 	return &OIDCHandler{
 		cfg:     cfg.withDefaults(),
@@ -43,6 +56,12 @@ func NewOIDCHandlerWithAuthenticator(cfg Config, authenticator *OIDCAuthenticato
 	}
 }
 
+// RegisterRoutes registers the OIDC authentication routes on the given Chi
+// router:
+//   - GET [Config.AuthorizePath] — initiates the OIDC authorize redirect
+//   - GET [Config.CallbackPath] — handles the OIDC callback and token exchange
+//   - GET [Config.TenantsPath] — lists the user's tenant memberships (JSON)
+//   - POST [Config.TenantSelectPath] — selects an active tenant (JSON body)
 func (h *OIDCHandler) RegisterRoutes(r chi.Router) {
 	r.Get(h.cfg.AuthorizePath, h.AuthorizeHandler)
 	r.Get(h.cfg.CallbackPath, h.CallbackHandler)
@@ -50,6 +69,9 @@ func (h *OIDCHandler) RegisterRoutes(r chi.Router) {
 	r.Post(h.cfg.TenantSelectPath, h.SelectTenantHandler)
 }
 
+// AuthorizeHandler initiates the OIDC authorization code flow by generating
+// a state parameter, storing it in a cookie, and redirecting to the identity
+// provider's authorization endpoint.
 func (h *OIDCHandler) AuthorizeHandler(w http.ResponseWriter, r *http.Request) {
 	state, err := generateState()
 	if err != nil {
@@ -61,6 +83,10 @@ func (h *OIDCHandler) AuthorizeHandler(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, h.oidc.AuthCodeURL(state), http.StatusFound)
 }
 
+// CallbackHandler handles the OIDC callback after user authentication. It
+// verifies the state parameter, exchanges the authorization code for tokens,
+// resolves or provisions the local user, and stores session claims. If the
+// user has multiple memberships, they are redirected to the tenant picker.
 func (h *OIDCHandler) CallbackHandler(w http.ResponseWriter, r *http.Request) {
 	stateCookie, err := r.Cookie(h.cfg.StateCookieName)
 	if err != nil {
@@ -159,6 +185,9 @@ func (h *OIDCHandler) CallbackHandler(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, h.cfg.PostLoginRedirect, http.StatusSeeOther)
 }
 
+// ListTenantsHandler returns the authenticated user's tenant memberships as
+// a JSON array. Each entry includes the tenant ID, name, role, and whether
+// it is the currently active tenant.
 func (h *OIDCHandler) ListTenantsHandler(w http.ResponseWriter, r *http.Request) {
 	claims, ok := h.getSessionClaims(r)
 	if !ok {
@@ -202,6 +231,9 @@ func (h *OIDCHandler) ListTenantsHandler(w http.ResponseWriter, r *http.Request)
 	json.NewEncoder(w).Encode(response)
 }
 
+// SelectTenantHandler accepts a JSON body with a "tenant_id" field and sets
+// it as the active tenant in the session. The user must be a member of the
+// specified tenant.
 func (h *OIDCHandler) SelectTenantHandler(w http.ResponseWriter, r *http.Request) {
 	claims, ok := h.getSessionClaims(r)
 	if !ok {

--- a/auth/middleware.go
+++ b/auth/middleware.go
@@ -12,21 +12,43 @@ import (
 	"github.com/kusold/gotchi/tenantctx"
 )
 
+// Mode determines how the authentication middleware handles unauthenticated
+// users and tenant selection requirements.
 type Mode string
 
 const (
+	// ModeAPI returns HTTP 401/409 JSON responses for unauthenticated or
+	// tenant-less requests.
 	ModeAPI Mode = "api"
-	ModeUI  Mode = "ui"
+	// ModeUI redirects to login or tenant picker pages for unauthenticated
+	// or tenant-less requests.
+	ModeUI Mode = "ui"
 )
 
+// MiddlewareConfig controls the behavior of [RequireAuthenticated] middleware.
 type MiddlewareConfig struct {
-	Mode                    Mode
-	SessionKey              string
-	LoginPath               string
-	TenantPickerPath        string
+	// Mode determines how unauthenticated/tenant-less requests are handled.
+	// Defaults to ModeAPI.
+	Mode Mode
+	// SessionKey is the session key where auth claims are stored.
+	// Defaults to [DefaultSessionKey].
+	SessionKey string
+	// LoginPath is the URL to redirect to when Mode is ModeUI.
+	// Defaults to [DefaultLoginPath].
+	LoginPath string
+	// TenantPickerPath is the URL to redirect to when a tenant selection
+	// is required and Mode is ModeUI. Defaults to [DefaultTenantPickerPath].
+	TenantPickerPath string
+	// AllowPathsWithoutTenant is a list of URL paths that are accessible
+	// without an active tenant. Supports "*" suffix for prefix matching
+	// (e.g. "/auth/*"). Defaults to the tenant picker and select paths.
 	AllowPathsWithoutTenant []string
-	LegacyTenantContextKey  any
-	LegacyClaimsContextKey  any
+	// LegacyTenantContextKey, when non-nil, causes the tenant ID to be set
+	// in context under this key for backward compatibility.
+	LegacyTenantContextKey any
+	// LegacyClaimsContextKey, when non-nil, causes the SessionClaims to be
+	// set in context under this key for backward compatibility.
+	LegacyClaimsContextKey any
 }
 
 func (c MiddlewareConfig) withDefaults() MiddlewareConfig {
@@ -49,6 +71,14 @@ func (c MiddlewareConfig) withDefaults() MiddlewareConfig {
 	return cfg
 }
 
+// RequireAuthenticated returns HTTP middleware that enforces authentication.
+// It checks for valid [SessionClaims] in the session and, if a tenant is
+// required, ensures one is selected. On success it sets the claims and tenant
+// ID in the request context via [WithSessionClaims] and [tenantctx.WithTenantID].
+//
+// In ModeAPI (default), unauthenticated requests receive 401 and tenant-less
+// requests receive 409 with a JSON body. In ModeUI, they are redirected to
+// the login page or tenant picker respectively.
 func RequireAuthenticated(sessionManager *session.Manager, cfg MiddlewareConfig) func(http.Handler) http.Handler {
 	conf := cfg.withDefaults()
 
@@ -121,6 +151,8 @@ func isTenantOptionalPath(path string, allowPaths []string) bool {
 	return false
 }
 
+// ActiveTenantID extracts the active tenant ID from the context. This is a
+// convenience wrapper around [tenantctx.TenantID].
 func ActiveTenantID(ctx context.Context) (uuid.UUID, bool) {
 	return tenantctx.TenantID(ctx)
 }

--- a/auth/oidc.go
+++ b/auth/oidc.go
@@ -9,31 +9,42 @@ import (
 	"golang.org/x/oauth2"
 )
 
+// UserInfoClaims maps the standard OIDC UserInfo claims to Go fields. Not all
+// fields will be populated by every identity provider.
 type UserInfoClaims struct {
-	Sub               string   `json:"sub"`
-	Acr               string   `json:"acr"`
-	Amr               []string `json:"amr"`
-	Aud               string   `json:"aud"`
-	Iss               string   `json:"iss"`
-	Sid               string   `json:"sid"`
-	AuthTime          float64  `json:"auth_time"`
-	Email             string   `json:"email"`
-	EmailVerified     bool     `json:"email_verified"`
-	Exp               float64  `json:"exp"`
-	GivenName         string   `json:"given_name"`
-	Groups            []string `json:"groups"`
-	Iat               float64  `json:"iat"`
-	Name              string   `json:"name"`
-	Nickname          string   `json:"nickname"`
-	PreferredUsername string   `json:"preferred_username"`
+	Sub               string   `json:"sub"`                // Subject identifier.
+	Acr               string   `json:"acr"`                // Authentication context class reference.
+	Amr               []string `json:"amr"`                // Authentication methods references.
+	Aud               string   `json:"aud"`                // Audience(s) of the token.
+	Iss               string   `json:"iss"`                // Issuer of the token.
+	Sid               string   `json:"sid"`                // Session ID.
+	AuthTime          float64  `json:"auth_time"`          // Time of authentication (epoch seconds).
+	Email             string   `json:"email"`              // User email address.
+	EmailVerified     bool     `json:"email_verified"`     // Whether email has been verified.
+	Exp               float64  `json:"exp"`                // Token expiration time (epoch seconds).
+	GivenName         string   `json:"given_name"`         // Given name (first name).
+	Groups            []string `json:"groups"`             // Group memberships.
+	Iat               float64  `json:"iat"`                // Issued at time (epoch seconds).
+	Name              string   `json:"name"`               // Full display name.
+	Nickname          string   `json:"nickname"`           // Nickname.
+	PreferredUsername string   `json:"preferred_username"` // Preferred username.
 }
 
+// OIDCProvider is the interface for OIDC provider operations. The standard
+// implementation uses [go-oidc] to discover endpoints from the issuer URL.
+// Implement this interface for testing with a mock provider.
 type OIDCProvider interface {
+	// Endpoint returns the OAuth2 authorization and token endpoints.
 	Endpoint() oauth2.Endpoint
+	// Verifier returns an IDTokenVerifier configured with the given OIDC config.
 	Verifier(*oidc.Config) *oidc.IDTokenVerifier
+	// UserInfo retrieves user claims from the provider using the given token source.
 	UserInfo(context.Context, oauth2.TokenSource) (*oidc.UserInfo, error)
 }
 
+// OIDCAuthenticator handles low-level OIDC operations: OAuth2 token exchange,
+// ID token verification, and UserInfo retrieval. It is used internally by
+// [OIDCHandler] but can also be used directly for custom authentication flows.
 type OIDCAuthenticator struct {
 	oauth2Config oauth2.Config
 	verifier     *oidc.IDTokenVerifier
@@ -41,6 +52,9 @@ type OIDCAuthenticator struct {
 	issuerURL    string
 }
 
+// NewOIDCAuthenticator creates a new OIDCAuthenticator by discovering the
+// provider's endpoints from the configured IssuerURL. Returns an error if
+// required config fields are missing or the provider cannot be reached.
 func NewOIDCAuthenticator(cfg Config) (*OIDCAuthenticator, error) {
 	parsedCfg := cfg.withDefaults()
 	if parsedCfg.IssuerURL == "" || parsedCfg.ClientID == "" || parsedCfg.ClientSecret == "" || parsedCfg.RedirectURL == "" {
@@ -60,6 +74,8 @@ func NewOIDCAuthenticator(cfg Config) (*OIDCAuthenticator, error) {
 	return NewOIDCAuthenticatorWithProvider(parsedCfg, provider)
 }
 
+// NewOIDCAuthenticatorWithProvider creates a new OIDCAuthenticator with a
+// pre-configured [OIDCProvider]. This is useful for testing with mock providers.
 func NewOIDCAuthenticatorWithProvider(cfg Config, provider OIDCProvider) (*OIDCAuthenticator, error) {
 	if provider == nil {
 		return nil, fmt.Errorf("oidc provider is required")
@@ -81,18 +97,25 @@ func NewOIDCAuthenticatorWithProvider(cfg Config, provider OIDCProvider) (*OIDCA
 	}, nil
 }
 
+// GetIssuer returns the OIDC issuer URL.
 func (o *OIDCAuthenticator) GetIssuer() string {
 	return o.issuerURL
 }
 
+// Exchange exchanges an OIDC authorization code for OAuth2 tokens.
 func (o *OIDCAuthenticator) Exchange(ctx context.Context, code string) (*oauth2.Token, error) {
 	return o.oauth2Config.Exchange(ctx, code)
 }
 
+// GetUserInfo retrieves user info from the OIDC provider using the given
+// access token.
 func (o *OIDCAuthenticator) GetUserInfo(ctx context.Context, token *oauth2.Token) (*oidc.UserInfo, error) {
 	return o.provider.UserInfo(ctx, oauth2.StaticTokenSource(token))
 }
 
+// VerifyIDToken extracts and verifies the ID token from the OAuth2 token
+// response. It validates the token signature and claims against the configured
+// client ID.
 func (o *OIDCAuthenticator) VerifyIDToken(ctx context.Context, token *oauth2.Token) (*oidc.IDToken, error) {
 	rawIDToken, ok := token.Extra("id_token").(string)
 	if !ok {
@@ -101,6 +124,7 @@ func (o *OIDCAuthenticator) VerifyIDToken(ctx context.Context, token *oauth2.Tok
 	return o.verifier.Verify(ctx, rawIDToken)
 }
 
+// AuthCodeURL returns the OIDC authorization URL with the given state parameter.
 func (o *OIDCAuthenticator) AuthCodeURL(state string) string {
 	return o.oauth2Config.AuthCodeURL(state)
 }

--- a/auth/postgres_store.go
+++ b/auth/postgres_store.go
@@ -13,16 +13,25 @@ import (
 	"github.com/kusold/gotchi/internal/db"
 )
 
+// PostgresStoreConfig configures the [PostgresIdentityStore].
 type PostgresStoreConfig struct {
+	// DefaultTenantName is the name used when creating the first tenant for a
+	// new user who has no existing tenant. Defaults to "Default".
 	DefaultTenantName string
 }
 
+// PostgresIdentityStore implements [IdentityStore] using PostgreSQL. It stores
+// users, tenants, and memberships in the database tables created by the auth
+// migrations ([migrations.Auth]).
 type PostgresIdentityStore struct {
 	pool    *pgxpool.Pool
 	queries *db.Queries
 	cfg     PostgresStoreConfig
 }
 
+// NewPostgresIdentityStore creates a new PostgreSQL-backed identity store.
+// The pool must be connected to a database with the auth schema migrations
+// applied.
 func NewPostgresIdentityStore(pool *pgxpool.Pool, cfg PostgresStoreConfig) (*PostgresIdentityStore, error) {
 	conf := cfg
 	if conf.DefaultTenantName == "" {
@@ -36,6 +45,7 @@ func NewPostgresIdentityStore(pool *pgxpool.Pool, cfg PostgresStoreConfig) (*Pos
 	}, nil
 }
 
+// ResolveOrProvisionUser implements [IdentityStore.ResolveOrProvisionUser].
 func (s *PostgresIdentityStore) ResolveOrProvisionUser(ctx context.Context, identity Identity) (UserRef, error) {
 	if s.pool == nil {
 		return UserRef{}, fmt.Errorf("postgres pool is required")
@@ -118,6 +128,7 @@ func (s *PostgresIdentityStore) ResolveOrProvisionUser(ctx context.Context, iden
 	}, nil
 }
 
+// ListMemberships implements [IdentityStore.ListMemberships].
 func (s *PostgresIdentityStore) ListMemberships(ctx context.Context, userID uuid.UUID) ([]Membership, error) {
 	rows, err := s.queries.ListMemberships(ctx, userID)
 	if err != nil {
@@ -135,6 +146,7 @@ func (s *PostgresIdentityStore) ListMemberships(ctx context.Context, userID uuid
 	return memberships, nil
 }
 
+// GetTenantDisplay implements [IdentityStore.GetTenantDisplay].
 func (s *PostgresIdentityStore) GetTenantDisplay(ctx context.Context, tenantID uuid.UUID) (TenantDisplay, error) {
 	row, err := s.queries.GetTenantByID(ctx, tenantID)
 	if err != nil {

--- a/auth/types.go
+++ b/auth/types.go
@@ -1,3 +1,48 @@
+// Package auth provides OpenID Connect (OIDC) authentication and multi-tenant
+// identity management for gotchi applications.
+//
+// The package handles the complete OIDC authorization code flow: redirecting
+// users to an identity provider, exchanging authorization codes for tokens,
+// resolving or provisioning local user records, and managing session state
+// including tenant selection for multi-tenant applications.
+//
+// # Quick Start
+//
+// The typical flow is orchestrated by the [app] package, but you can use the
+// auth package directly:
+//
+//	// Create a PostgreSQL identity store.
+//	store, err := auth.NewPostgresIdentityStore(pool, auth.PostgresStoreConfig{})
+//
+//	// Create the OIDC handler to manage authentication routes.
+//	handler, err := auth.NewOIDCHandler(auth.Config{
+//	    Enabled:      true,
+//	    IssuerURL:    "https://auth.example.com",
+//	    ClientID:     "my-client",
+//	    ClientSecret: "my-secret",
+//	    RedirectURL:  "https://myapp.com/oidc/callback",
+//	}, sessionMgr, store)
+//
+//	// Register OIDC routes on your Chi router.
+//	handler.RegisterRoutes(r)
+//
+//	// Protect routes with authentication middleware.
+//	r.Group(func(protected chi.Router) {
+//	    protected.Use(auth.RequireAuthenticated(sessionMgr, auth.MiddlewareConfig{}))
+//	    protected.Get("/profile", profileHandler)
+//	})
+//
+// # Key Concepts
+//
+//   - [OIDCHandler] manages the OIDC authorization code flow, including the
+//     authorize redirect, callback handling, and tenant selection.
+//   - [IdentityStore] is the interface for resolving OIDC identities to local
+//     users and managing tenant memberships. Use [PostgresIdentityStore] for
+//     PostgreSQL-backed storage.
+//   - [SessionClaims] holds the authenticated user's session data, including
+//     the active tenant ID, and is stored in the session.
+//   - [RequireAuthenticated] is middleware that enforces authentication and
+//     optionally requires tenant selection before allowing access.
 package auth
 
 import (
@@ -7,70 +52,108 @@ import (
 	"github.com/google/uuid"
 )
 
+// Default configuration values for auth paths and settings.
 const (
-	DefaultSessionKey         = "auth"
-	DefaultLoginPath          = "/auth/login"
-	DefaultTenantPickerPath   = "/auth/tenants"
-	DefaultPostLoginRedirect  = "/ui/profile"
-	DefaultAuthorizePath      = "/oidc/authorize"
-	DefaultCallbackPath       = "/oidc/callback"
-	DefaultTenantsPath        = "/tenants"
-	DefaultTenantSelectPath   = "/tenant/select"
-	DefaultStateCookieName    = "oidc_state"
+	// DefaultSessionKey is the default session key used to store auth claims.
+	DefaultSessionKey = "auth"
+	// DefaultLoginPath is the default path for the login page.
+	DefaultLoginPath = "/auth/login"
+	// DefaultTenantPickerPath is the default path for the tenant selection UI.
+	DefaultTenantPickerPath = "/auth/tenants"
+	// DefaultPostLoginRedirect is the default URL to redirect to after login.
+	DefaultPostLoginRedirect = "/ui/profile"
+	// DefaultAuthorizePath is the default path that initiates the OIDC authorize flow.
+	DefaultAuthorizePath = "/oidc/authorize"
+	// DefaultCallbackPath is the default OIDC callback path.
+	DefaultCallbackPath = "/oidc/callback"
+	// DefaultTenantsPath is the default API path for listing a user's tenants.
+	DefaultTenantsPath = "/tenants"
+	// DefaultTenantSelectPath is the default API path for selecting an active tenant.
+	DefaultTenantSelectPath = "/tenant/select"
+	// DefaultStateCookieName is the default cookie name for the OIDC state parameter.
+	DefaultStateCookieName = "oidc_state"
+	// DefaultCookieMaxAgeSecond is the default max age (in seconds) for the state cookie.
 	DefaultCookieMaxAgeSecond = 3600
 )
 
+// Role represents a user's role within a tenant.
 type Role string
 
 const (
-	RoleOwner  Role = "owner"
-	RoleAdmin  Role = "admin"
+	// RoleOwner is the highest-privilege role, typically the tenant creator.
+	RoleOwner Role = "owner"
+	// RoleAdmin can manage users and settings within a tenant.
+	RoleAdmin Role = "admin"
+	// RoleMember is the standard role for tenant members.
 	RoleMember Role = "member"
 )
 
+// Identity represents a user's identity as extracted from OIDC claims. It is
+// the input to [IdentityStore.ResolveOrProvisionUser].
 type Identity struct {
-	Issuer            string
-	Subject           string
-	Email             string
-	EmailVerified     bool
-	Username          string
-	Name              string
-	PreferredUsername string
-	RawClaims         map[string]any
+	Issuer            string         // The OIDC issuer URL (e.g. "https://auth.example.com").
+	Subject           string         // The unique subject identifier from the IDP.
+	Email             string         // The user's email address.
+	EmailVerified     bool           // Whether the email has been verified by the IDP.
+	Username          string         // The user's username (nickname).
+	Name              string         // The user's display name.
+	PreferredUsername string         // The user's preferred username.
+	RawClaims         map[string]any // Any additional claims from the ID token.
 }
 
+// UserRef is a reference to a resolved local user, containing both the local
+// user ID and the OIDC issuer/subject pair that uniquely identifies the user
+// across identity providers.
 type UserRef struct {
-	UserID  uuid.UUID
-	Issuer  string
-	Subject string
+	UserID  uuid.UUID // The local database user ID.
+	Issuer  string    // The OIDC issuer URL.
+	Subject string    // The OIDC subject identifier.
 }
 
+// Membership represents a user's membership in a tenant, including their role.
 type Membership struct {
-	TenantID   uuid.UUID
-	TenantName string
-	Role       Role
+	TenantID   uuid.UUID // The tenant's unique ID.
+	TenantName string    // The human-readable tenant name.
+	Role       Role      // The user's role within the tenant.
 }
 
+// TenantDisplay holds basic display information for a tenant.
 type TenantDisplay struct {
-	TenantID uuid.UUID
-	Name     string
+	TenantID uuid.UUID // The tenant's unique ID.
+	Name     string    // The human-readable tenant name.
 }
 
+// IdentityStore is the interface for resolving OIDC identities to local users
+// and managing tenant memberships. Implementations handle user provisioning
+// (auto-creating users on first login) and membership queries.
+//
+// The built-in [PostgresIdentityStore] implements this interface using
+// PostgreSQL. For testing or custom backends, implement this interface directly.
 type IdentityStore interface {
+	// ResolveOrProvisionUser looks up an existing user by their OIDC issuer and
+	// subject. If no user exists, it creates one along with a default tenant
+	// membership.
 	ResolveOrProvisionUser(ctx context.Context, identity Identity) (UserRef, error)
+	// ListMemberships returns all tenant memberships for the given user.
 	ListMemberships(ctx context.Context, userID uuid.UUID) ([]Membership, error)
+	// GetTenantDisplay returns display information for a specific tenant.
 	GetTenantDisplay(ctx context.Context, tenantID uuid.UUID) (TenantDisplay, error)
 }
 
-// Hooks is kept as a compatibility alias.
+// Hooks is a compatibility alias for [IdentityStore].
 type Hooks = IdentityStore
 
+// SessionClaims holds the authenticated user's session data. It is stored in
+// the session under [DefaultSessionKey] and can be retrieved from context
+// using [SessionClaimsFromContext].
 type SessionClaims struct {
-	Authenticated  bool
-	UserID         uuid.UUID
-	Issuer         string
-	Subject        string
-	ActiveTenantID *uuid.UUID
+	Authenticated  bool       // True after successful OIDC authentication.
+	UserID         uuid.UUID  // The local database user ID.
+	Issuer         string     // The OIDC issuer URL.
+	Subject        string     // The OIDC subject identifier.
+	ActiveTenantID *uuid.UUID // The currently selected tenant, or nil if not yet selected.
 }
 
+// ErrTenantSelectionRequired is returned when a user has multiple tenant
+// memberships but has not yet selected an active tenant.
 var ErrTenantSelectionRequired = errors.New("tenant selection required")

--- a/db/db.go
+++ b/db/db.go
@@ -1,3 +1,36 @@
+// Package db provides database connection management for gotchi applications
+// with built-in support for multi-tenancy, schema migrations, and OpenTelemetry
+// tracing.
+//
+// The [Manager] type handles the lifecycle of a PostgreSQL connection pool
+// ([pgxpool.Pool]) with automatic tenant isolation via the [tenantctx] package.
+// When a connection is acquired from the pool, it automatically sets the tenant
+// context using the PostgreSQL set_tenant function if one is present in the
+// request context.
+//
+// # Quick Start
+//
+// Create a manager, register migrations, connect, and run them:
+//
+//	dbMgr := db.NewManager(db.Config{
+//	    DatabaseURL: "postgres://user:pass@localhost:5432/mydb",
+//	})
+//	dbMgr.AddMigrationSource(db.MigrationSource{
+//	    FS:  migrations.Core(),
+//	    Dir: ".",
+//	})
+//	if err := dbMgr.Connect(ctx); err != nil {
+//	    log.Fatal(err)
+//	}
+//	if err := dbMgr.RunMigrations(ctx); err != nil {
+//	    log.Fatal(err)
+//	}
+//
+// # Multi-Tenancy
+//
+// Connections automatically apply tenant isolation based on the tenant ID stored
+// in the request context via [tenantctx.WithTenantID]. Use [AdminContext] for
+// operations that should bypass tenant filtering (e.g., migrations).
 package db
 
 import (
@@ -19,28 +52,45 @@ import (
 	"github.com/kusold/gotchi/tenantctx"
 )
 
+// Config holds the settings for connecting to a PostgreSQL database.
 type Config struct {
-	DatabaseURL       string
-	SearchPath        string // Optional: set search_path for all connections (used by migration-regression)
+	// DatabaseURL is the PostgreSQL connection string (e.g.
+	// "postgres://user:pass@host:5432/dbname?sslmode=disable"). Required.
+	DatabaseURL string
+	// SearchPath optionally sets the PostgreSQL search_path for all connections.
+	// This is primarily used for migration tooling.
+	SearchPath string
+	// EnableSlogTracing enables pgx query logging via slog at trace level.
 	EnableSlogTracing bool
-	OTELTracing       bool
+	// OTELTracing enables OpenTelemetry tracing for database queries via otelpgx.
+	OTELTracing bool
 }
 
+// MigrationSource describes a set of SQL migration files to apply. FS is an
+// [fs.FS] containing goose-formatted .sql files, and Dir is the subdirectory
+// within FS to use (defaults to "." when empty).
 type MigrationSource struct {
 	FS  fs.FS
 	Dir string
 }
 
+// Manager manages the lifecycle of a PostgreSQL connection pool with support
+// for multi-tenancy and migrations. Create one with [NewManager], register
+// migration sources, then call [Manager.Connect] to establish the pool.
 type Manager struct {
 	cfg            Config
 	pool           *pgxpool.Pool
 	migrationFiles []MigrationSource
 }
 
+// NewManager creates a new database Manager with the given configuration.
+// The returned Manager has no pool until [Manager.Connect] is called.
 func NewManager(cfg Config) *Manager {
 	return &Manager{cfg: cfg}
 }
 
+// AddMigrationSource registers a migration source to be applied when
+// [Manager.RunMigrations] is called. If source.Dir is empty it defaults to ".".
 func (m *Manager) AddMigrationSource(source MigrationSource) {
 	if source.Dir == "" {
 		source.Dir = "."
@@ -48,6 +98,9 @@ func (m *Manager) AddMigrationSource(source MigrationSource) {
 	m.migrationFiles = append(m.migrationFiles, source)
 }
 
+// Connect establishes the connection pool using the configured DatabaseURL.
+// If a pool already exists it returns nil immediately. After connecting it
+// pings the database using an [AdminContext] to verify connectivity.
 func (m *Manager) Connect(ctx context.Context) error {
 	if m.pool != nil {
 		return nil
@@ -75,10 +128,13 @@ func (m *Manager) Connect(ctx context.Context) error {
 	return m.Ping(AdminContext(ctx))
 }
 
+// EnableOTELTracing enables OpenTelemetry tracing on the database connections.
+// This must be called before [Manager.Connect] to take effect.
 func (m *Manager) EnableOTELTracing() {
 	m.cfg.OTELTracing = true
 }
 
+// Close shuts down the connection pool and releases all resources.
 func (m *Manager) Close() error {
 	if m.pool != nil {
 		m.pool.Close()
@@ -86,6 +142,8 @@ func (m *Manager) Close() error {
 	return nil
 }
 
+// Ping verifies connectivity to the database. Returns an error if the pool
+// has not been initialized.
 func (m *Manager) Ping(ctx context.Context) error {
 	if m.pool == nil {
 		return fmt.Errorf("database pool is not initialized")
@@ -93,10 +151,15 @@ func (m *Manager) Ping(ctx context.Context) error {
 	return m.pool.Ping(ctx)
 }
 
+// Pool returns the underlying pgxpool.Pool. Returns nil if [Manager.Connect]
+// has not been called.
 func (m *Manager) Pool() *pgxpool.Pool {
 	return m.pool
 }
 
+// RunMigrations applies all registered migration sources in order using
+// goose. Migrations are run using an [AdminContext] to bypass tenant
+// isolation. Returns nil immediately if no migration sources are registered.
 func (m *Manager) RunMigrations(ctx context.Context) error {
 	if m.pool == nil {
 		return fmt.Errorf("database pool is not initialized")
@@ -121,6 +184,9 @@ func (m *Manager) RunMigrations(ctx context.Context) error {
 	return nil
 }
 
+// AdminContext returns a context with the system tenant set, bypassing
+// tenant isolation. Use this for administrative operations like migrations
+// or internal queries that need access to all tenant data.
 func AdminContext(ctx context.Context) context.Context {
 	if ctx == nil {
 		ctx = context.Background()

--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -1,3 +1,24 @@
+// Package scaffold generates boilerplate files for new gotchi applications.
+//
+// It produces a ready-to-run project structure including a Go module file,
+// a main entry point wired to the gotchi [app] and [db] packages, an example
+// module with a health-check endpoint, an embedded SQL migration, a Docker
+// Compose configuration, an environment variable template, a README, and a
+// GitHub Actions CI workflow.
+//
+// Typical usage is through the CLI command "gotchi init", which calls
+// [Generate] to build the file map and [Write] to persist files to disk:
+//
+//	files, err := scaffold.Generate(scaffold.Options{
+//	    AppName:    "my-app",
+//	    ModulePath: "github.com/example/my-app",
+//	})
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	if err := scaffold.Write("/path/to/project", files); err != nil {
+//	    log.Fatal(err)
+//	}
 package scaffold
 
 import (
@@ -8,11 +29,38 @@ import (
 	"strings"
 )
 
+// Options holds the parameters that configure scaffold generation.
+//
+// AppName is used in the README title, Docker Compose database name, and
+// the environment variable template. ModulePath is the Go module path
+// written to go.mod and used in import statements throughout the generated
+// source files. Both fields are required.
 type Options struct {
-	AppName    string
+	// AppName is the human-readable application name (e.g. "my-app").
+	AppName string
+	// ModulePath is the Go module import path (e.g. "github.com/example/my-app").
 	ModulePath string
 }
 
+// Generate creates a map of file paths to their contents for a new gotchi
+// application. The returned map keys are slash-separated relative paths
+// (e.g. "cmd/server/main.go") and the values are the complete file contents
+// as strings.
+//
+// Both opts.AppName and opts.ModulePath must be non-empty. If either is
+// blank or contains only whitespace, Generate returns an error.
+//
+// The generated files include:
+//   - go.mod: Go module file declaring a dependency on github.com/kusold/gotchi.
+//   - cmd/server/main.go: Application entry point that wires config, database,
+//     migrations, and a single module.
+//   - internal/module/module.go: Example module with a /healthz endpoint.
+//   - migrations/migrations.go: Embedded migration filesystem declaration.
+//   - migrations/20260101000000_example.sql: Example goose migration.
+//   - .env.sample: Template for required environment variables.
+//   - docker-compose.yaml: PostgreSQL service for local development.
+//   - README.md: Quick-start guide referencing the AppName.
+//   - .github/workflows/test.yaml: CI workflow that runs "go test ./...".
 func Generate(opts Options) (map[string]string, error) {
 	if strings.TrimSpace(opts.AppName) == "" {
 		return nil, fmt.Errorf("app name is required")
@@ -155,6 +203,14 @@ jobs:
 	return files, nil
 }
 
+// Write persists a map of files to the filesystem. For each entry in files,
+// it creates any missing parent directories under root and writes the content
+// with permissions 0o644. If a file already exists at the target path it is
+// overwritten.
+//
+// root must be an existing directory (or an empty string to write relative
+// to the working directory). An error is returned if directory creation or
+// any file write fails; files written before the failure are not rolled back.
 func Write(root string, files map[string]string) error {
 	for path, content := range files {
 		target := filepath.Join(root, path)
@@ -168,6 +224,9 @@ func Write(root string, files map[string]string) error {
 	return nil
 }
 
+// FileList returns the keys of the files map as a sorted slice of paths.
+// It is useful for displaying or logging the set of files that will be
+// generated.
 func FileList(files map[string]string) []string {
 	list := make([]string, 0, len(files))
 	for path := range files {

--- a/migrations/migrations.go
+++ b/migrations/migrations.go
@@ -1,3 +1,27 @@
+// Package migrations provides embedded SQL migration files for gotchi's core
+// schema and authentication schema. Each function returns an [fs.FS] that can be
+// passed to [db.Manager.AddMigrationSource].
+//
+// The migrations use the goose migration format with SQL files embedded at
+// compile time via [embed.FS]. Two migration sets are provided:
+//
+//   - [Core]: creates the foundational multi-tenant schema (tenants, users,
+//     memberships, etc.).
+//   - [Auth]: creates the OIDC authentication tables and related schema.
+//
+// # Usage with the db package
+//
+// Pass the returned filesystems to the database manager before connecting:
+//
+//	dbMgr := db.NewManager(dbConfig)
+//	dbMgr.AddMigrationSource(db.MigrationSource{
+//	    FS:  migrations.Core(),
+//	    Dir: ".",
+//	})
+//	dbMgr.AddMigrationSource(db.MigrationSource{
+//	    FS:  migrations.Auth(),
+//	    Dir: ".",
+//	})
 package migrations
 
 import (
@@ -5,9 +29,13 @@ import (
 	"io/fs"
 )
 
+// migrationFS holds the embedded SQL migration files from the core/ and auth/
+// subdirectories. The go:embed directive includes all .sql files at build time.
+//
 //go:embed core/*.sql auth/*.sql
 var migrationFS embed.FS
 
+// subFS returns a sub-filesystem rooted at dir within migrationFS.
 func subFS(dir string) fs.FS {
 	sub, err := fs.Sub(migrationFS, dir)
 	if err != nil {
@@ -16,10 +44,16 @@ func subFS(dir string) fs.FS {
 	return sub
 }
 
+// Core returns the embedded filesystem containing core gotchi database
+// migrations. These migrations create the foundational multi-tenant schema
+// including tenants, users, and membership tables.
 func Core() fs.FS {
 	return subFS("core")
 }
 
+// Auth returns the embedded filesystem containing authentication-related
+// database migrations. These migrations create OIDC identity tables and
+// related auth schema extensions.
 func Auth() fs.FS {
 	return subFS("auth")
 }

--- a/observability/middleware.go
+++ b/observability/middleware.go
@@ -1,3 +1,45 @@
+// Package observability provides HTTP middleware for request correlation, audit
+// logging, and OpenTelemetry (OTEL) tracing and metrics in the gotchi framework.
+//
+// The package is organized around two main concerns:
+//
+//   - Request correlation and audit logging via [CorrelationAndAudit], which
+//     assigns (or propagates) a unique request ID, enriches the structured log
+//     with method, path, status code, duration, and (when a session is present)
+//     user and tenant identifiers.
+//   - OpenTelemetry integration via [SetupOTEL], [OTELTracingMiddleware], and
+//     [OTELMetricsMiddleware], which configure an OTLP exporter and inject
+//     per-request spans and metrics that use Chi route patterns (e.g.
+//     "/users/{id}") as low-cardinality attributes.
+//
+// # Quick Start
+//
+// Set up OpenTelemetry early in your application startup:
+//
+//	shutdown, err := observability.SetupOTEL(ctx, observability.OTELConfig{
+//	    Enabled:     true,
+//	    ServiceName: "my-service",
+//	    ExporterURL: "localhost:4317",
+//	    Insecure:    true,
+//	})
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	defer shutdown(context.Background())
+//
+// Then apply the middleware stack to a Chi router:
+//
+//	r := chi.NewRouter()
+//	r.Use(observability.CorrelationAndAudit(sessionMgr, "session"))
+//	r.Use(observability.OTELTracingMiddleware("my-service"))
+//	r.Use(observability.OTELMetricsMiddleware("my-service"))
+//
+// # Request IDs
+//
+// Every request passing through [CorrelationAndAudit] receives a UUID-based
+// request ID (propagated from the X-Request-ID header when present, or
+// generated automatically). The ID is stored in the request context and can be
+// retrieved with [RequestID].
 package observability
 
 import (
@@ -11,10 +53,18 @@ import (
 	"github.com/kusold/gotchi/session"
 )
 
+// requestIDContextKey is an unexported type used as the context key for the
+// request ID value. Using an unexported type prevents collisions with keys
+// defined in other packages.
 type requestIDContextKey struct{}
 
+// requestIDKey is the concrete context key instance for storing and retrieving
+// the request ID.
 var requestIDKey = requestIDContextKey{}
 
+// RequestID retrieves the request ID from the given context. It returns the ID
+// string and true if a non-empty request ID is present, or ("", false) if the
+// context carries no request ID, an empty one, or a value of the wrong type.
 func RequestID(ctx context.Context) (string, bool) {
 	v, ok := ctx.Value(requestIDKey).(string)
 	if !ok || v == "" {
@@ -23,10 +73,35 @@ func RequestID(ctx context.Context) (string, bool) {
 	return v, true
 }
 
+// WithRequestID returns a new context derived from ctx that carries the given
+// requestID. It is used internally by [CorrelationAndAudit] but is exported so
+// callers can propagate the ID in downstream goroutines or tests.
 func WithRequestID(ctx context.Context, requestID string) context.Context {
 	return context.WithValue(ctx, requestIDKey, requestID)
 }
 
+// CorrelationAndAudit returns an HTTP middleware that assigns each request a
+// correlation ID, records a structured audit log line, and propagates the ID
+// through the X-Request-ID header and request context.
+//
+// If the incoming request already carries an X-Request-ID header its value is
+// reused; otherwise a new UUID v4 is generated. The ID is written to the
+// response header so callers can correlate logs with the downstream response.
+//
+// The audit log entry (written at slog.InfoLevel) includes the following
+// structured fields:
+//
+//	request_id   – the correlation ID
+//	method       – HTTP method
+//	path         – request URL path
+//	status       – response status code
+//	duration_ms  – request duration in milliseconds
+//	user_id      – (optional) from session claims
+//	tenant_id    – (optional) from session claims
+//
+// When sessionManager is non-nil the middleware reads [auth.SessionClaims]
+// from the session store using sessionKey. If sessionKey is empty it defaults
+// to [auth.DefaultSessionKey].
 func CorrelationAndAudit(sessionManager *session.Manager, sessionKey string) func(http.Handler) http.Handler {
 	key := sessionKey
 	if key == "" {
@@ -72,11 +147,14 @@ func CorrelationAndAudit(sessionManager *session.Manager, sessionKey string) fun
 	}
 }
 
+// statusRecorder wraps an http.ResponseWriter to capture the status code.
 type statusRecorder struct {
 	http.ResponseWriter
 	status int
 }
 
+// WriteHeader intercepts the status code before delegating to the underlying
+// ResponseWriter.
 func (sr *statusRecorder) WriteHeader(statusCode int) {
 	sr.status = statusCode
 	sr.ResponseWriter.WriteHeader(statusCode)

--- a/observability/otel.go
+++ b/observability/otel.go
@@ -24,7 +24,7 @@ import (
 )
 
 // routePattern extracts the matched route template from Chi's RouteContext.
-// If no route was matched (e.g. 404), it returns a static placeholder to
+// If no route was matched (e.g. 404), it returns an empty string to
 // prevent high-cardinality attribute values from unmatched paths.
 func routePattern(r *http.Request) string {
 	rctx := chi.RouteContext(r.Context())
@@ -37,17 +37,41 @@ func routePattern(r *http.Request) string {
 	return ""
 }
 
+// OTELConfig configures the OpenTelemetry setup. A zero-value config is not
+// valid; at minimum set Enabled to true. Use [OTELConfig.WithDefaults] to
+// populate default values for ServiceName, ExporterURL, SampleRate, and
+// ShutdownTimeout.
 type OTELConfig struct {
-	Enabled         bool
-	EnableTracing   *bool
-	EnableMetrics   *bool
-	ServiceName     string
-	ExporterURL     string
-	SampleRate      *float64
-	Insecure        bool
+	// Enabled controls whether OpenTelemetry is active. When false,
+	// [SetupOTEL] is a no-op and tracing/metrics middleware passes requests
+	// through without instrumentation.
+	Enabled bool
+	// EnableTracing controls whether traces are collected. Defaults to true
+	// when nil. Use a pointer to distinguish "not set" from "explicitly false".
+	EnableTracing *bool
+	// EnableMetrics controls whether metrics are collected. Defaults to true
+	// when nil. Use a pointer to distinguish "not set" from "explicitly false".
+	EnableMetrics *bool
+	// ServiceName identifies this service in traces and metrics. Defaults to
+	// "gotchi" when empty.
+	ServiceName string
+	// ExporterURL is the OTLP gRPC endpoint (e.g. "localhost:4317"). Defaults
+	// to "localhost:4317" when empty.
+	ExporterURL string
+	// SampleRate controls the trace sampling ratio (0.0–1.0). Defaults to 1.0
+	// (all traces) when nil.
+	SampleRate *float64
+	// Insecure disables TLS for the OTLP gRPC connection. Useful for local
+	// development with collectors like Jaeger or the OpenTelemetry Collector.
+	Insecure bool
+	// ShutdownTimeout is the maximum duration to wait for pending spans and
+	// metrics to be exported during shutdown. Defaults to 5 seconds.
 	ShutdownTimeout time.Duration
 }
 
+// WithDefaults returns a copy of the config with zero values replaced by
+// sensible defaults: ServiceName="gotchi", ExporterURL="localhost:4317",
+// SampleRate=1.0, ShutdownTimeout=5s, EnableTracing=true, EnableMetrics=true.
 func (c OTELConfig) WithDefaults() OTELConfig {
 	cfg := c
 	if cfg.ServiceName == "" {
@@ -71,10 +95,14 @@ func (c OTELConfig) WithDefaults() OTELConfig {
 	return cfg
 }
 
+// TracingEnabled reports whether tracing is both globally enabled and
+// explicitly enabled via EnableTracing.
 func (c OTELConfig) TracingEnabled() bool {
 	return c.Enabled && c.EnableTracing != nil && *c.EnableTracing
 }
 
+// MetricsEnabled reports whether metrics are both globally enabled and
+// explicitly enabled via EnableMetrics.
 func (c OTELConfig) MetricsEnabled() bool {
 	return c.Enabled && c.EnableMetrics != nil && *c.EnableMetrics
 }
@@ -82,6 +110,22 @@ func (c OTELConfig) MetricsEnabled() bool {
 func boolPtr(b bool) *bool          { return &b }
 func float64Ptr(f float64) *float64 { return &f }
 
+// SetupOTEL initializes the OpenTelemetry tracer provider and meter provider,
+// configured to export to an OTLP gRPC endpoint. It returns a shutdown function
+// that must be called on application exit to flush pending telemetry.
+//
+// The function configures:
+//   - A TracerProvider with the given sampling rate and OTLP gRPC exporter.
+//   - A MeterProvider with a periodic reader exporting to the same endpoint.
+//   - A composite TextMapPropagator for trace context and baggage propagation.
+//
+// Call the returned shutdown function in a defer to ensure telemetry is flushed:
+//
+//	shutdown, err := observability.SetupOTEL(ctx, cfg)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	defer shutdown(context.Background())
 func SetupOTEL(ctx context.Context, cfg OTELConfig) (func(context.Context) error, error) {
 	cfg = cfg.WithDefaults()
 
@@ -138,6 +182,13 @@ func SetupOTEL(ctx context.Context, cfg OTELConfig) (func(context.Context) error
 	}, nil
 }
 
+// OTELTracingMiddleware returns HTTP middleware that creates an OpenTelemetry span
+// for each request. After the handler completes, it updates the span name with
+// the matched Chi route pattern (e.g. "GET /users/{id}") and records the HTTP
+// status code. Server errors (5xx) are marked as error spans.
+//
+// Place this middleware after [CorrelationAndAudit] but before route-specific
+// middleware to capture the full request lifecycle.
 func OTELTracingMiddleware(serviceName string) func(http.Handler) http.Handler {
 	tracer := otel.Tracer(serviceName)
 	propagator := otel.GetTextMapPropagator()
@@ -178,6 +229,10 @@ func OTELTracingMiddleware(serviceName string) func(http.Handler) http.Handler {
 	}
 }
 
+// OTELMetricsMiddleware returns HTTP middleware that records request duration
+// (histogram in milliseconds) and request count (counter) as OpenTelemetry
+// metrics. Metrics are labeled with HTTP method, status code, and (when
+// available) the matched Chi route pattern for low-cardinality grouping.
 func OTELMetricsMiddleware(serviceName string) func(http.Handler) http.Handler {
 	meter := otel.Meter(serviceName)
 	duration, err := meter.Float64Histogram(
@@ -217,6 +272,9 @@ func OTELMetricsMiddleware(serviceName string) func(http.Handler) http.Handler {
 	}
 }
 
+// getStatusRecorder returns an existing statusRecorder wrapping w, or creates
+// a new one. This avoids double-wrapping when both tracing and metrics
+// middleware are applied.
 func getStatusRecorder(w http.ResponseWriter) *statusRecorder {
 	if existing, ok := w.(*statusRecorder); ok {
 		return existing

--- a/openapi/openapi.go
+++ b/openapi/openapi.go
@@ -1,3 +1,26 @@
+// Package openapi provides HTTP middleware for validating requests and responses
+// against an OpenAPI specification, and utilities for mounting oapi-codegen
+// generated handlers onto a Chi router.
+//
+// # Request Validation
+//
+// Use [Validator] to create middleware that validates incoming requests against
+// an OpenAPI spec. Invalid requests receive a structured JSON error response:
+//
+//	spec, _ := os.ReadFile("openapi.yaml")
+//	r.Use(openapi.Validator(spec, openapi.Config{}))
+//
+// # Mounting oapi-codegen Handlers
+//
+// Use [MountChi] to register oapi-codegen generated server interfaces on a
+// Chi router with optional middleware groups:
+//
+//	openapi.MountChi(r, myHandler, MyServerRegisterer, authMiddleware)
+//
+// # Custom Error Encoding
+//
+// Implement the [ErrorEncoder] interface or use [ErrorEncoderFunc] to customize
+// how validation errors are rendered to clients.
 package openapi
 
 import (
@@ -17,31 +40,47 @@ import (
 	validationErrors "github.com/pb33f/libopenapi-validator/errors"
 )
 
+// ErrorDetail describes a single validation failure in a structured format.
 type ErrorDetail struct {
-	Type   string `json:"type,omitempty"`
-	Reason string `json:"reason,omitempty"`
+	Type   string `json:"type,omitempty"`  // The validation error type (e.g. "schema").
+	Reason string `json:"reason,omitempty"` // Human-readable explanation of the error.
 }
 
+// ErrorPayload is the top-level JSON structure returned when request validation
+// fails. Message contains a human-readable summary; Errors provides granular
+// details for each validation violation.
 type ErrorPayload struct {
-	Message string        `json:"message"`
-	Errors  []ErrorDetail `json:"errors,omitempty"`
+	Message string        `json:"message"`            // Human-readable summary of the validation failure.
+	Errors  []ErrorDetail `json:"errors,omitempty"`   // Detailed validation errors, if available.
 }
 
+// ErrorEncoder encodes validation error responses into an HTTP response.
+// Implement this interface to customize error output format.
 type ErrorEncoder interface {
 	Encode(w http.ResponseWriter, statusCode int, payload ErrorPayload)
 }
 
+// ErrorEncoderFunc is a function adapter for the [ErrorEncoder] interface.
 type ErrorEncoderFunc func(w http.ResponseWriter, statusCode int, payload ErrorPayload)
 
+// Encode calls f(w, statusCode, payload), satisfying the [ErrorEncoder] interface.
 func (f ErrorEncoderFunc) Encode(w http.ResponseWriter, statusCode int, payload ErrorPayload) {
 	f(w, statusCode, payload)
 }
 
+// Config controls the behavior of the validation middleware. A zero-value
+// Config is valid and uses sensible defaults.
 type Config struct {
-	ErrorEncoder        ErrorEncoder
+	// ErrorEncoder formats and writes validation error responses. When nil,
+	// a default JSON encoder is used.
+	ErrorEncoder ErrorEncoder
+	// MaxRequestBodyBytes is the maximum allowed size for request bodies.
+	// Requests exceeding this limit receive a 413 response. Defaults to
+	// 1 MiB (DefaultMaxRequestBodyBytes) when zero or negative.
 	MaxRequestBodyBytes int64
 }
 
+// DefaultMaxRequestBodyBytes is the default maximum request body size (1 MiB).
 const DefaultMaxRequestBodyBytes int64 = 1 << 20
 
 var errRequestBodyTooLarge = errors.New("request body too large")

--- a/session/example_test.go
+++ b/session/example_test.go
@@ -1,0 +1,297 @@
+package session_test
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/kusold/gotchi/session"
+)
+
+// ExampleNewMemory demonstrates creating an in-memory session manager with
+// custom configuration and using it as HTTP middleware.
+func ExampleNewMemory() {
+	mgr := session.NewMemory(session.Config{
+		Lifetime:       12 * time.Hour,
+		CookieName:     "myapp-session",
+		CookieSecure:   true,
+		CookieSameSite: http.SameSiteStrictMode,
+	})
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Store a value in the session.
+		mgr.Put(r.Context(), "username", "alice")
+
+		// Retrieve it in the same or a subsequent request.
+		username := mgr.GetString(r.Context(), "username")
+		fmt.Fprintf(w, "Hello, %s!", username)
+	})
+
+	// Wrap the handler with session middleware.
+	http.Handle("/", mgr.LoadAndSave(handler))
+}
+
+// ExampleNewMemory_defaultConfig demonstrates creating an in-memory session
+// manager using all default configuration values.
+func ExampleNewMemory_defaultConfig() {
+	mgr := session.NewMemory(session.Config{})
+
+	// Defaults applied:
+	//   ExpiryInterval = 5 minutes
+	//   Lifetime       = 24 hours
+	//   CookieName     = "session"
+	//   CookieSecure   = false
+	//   CookieSameSite = http.SameSiteLaxMode
+
+	inner := mgr.Inner()
+	fmt.Println("Cookie name:", inner.Cookie.Name)
+	fmt.Println("Lifetime:", inner.Lifetime)
+	// Output:
+	// Cookie name: session
+	// Lifetime: 24h0m0s
+}
+
+// ExampleNewPostgres demonstrates creating a PostgreSQL-backed session manager.
+func ExampleNewPostgres() {
+	// In a real application, obtain the pool from your database configuration.
+	// pool, err := pgxpool.New(context.Background(), os.Getenv("DATABASE_URL"))
+	// if err != nil {
+	//     log.Fatal(err)
+	// }
+	// defer pool.Close()
+
+	// For this example, pool is nil; replace with a real pool in production.
+	var pool interface{} // placeholder — use *pgxpool.Pool in real code
+	_ = pool
+
+	// Uncomment the following lines when you have a real pool:
+	// mgr := session.NewPostgres(session.Config{
+	//     Lifetime:   24 * time.Hour,
+	//     CookieName: "prod-session",
+	// }, pool, "user_sessions")
+
+	fmt.Println("Use NewPostgres with a real *pgxpool.Pool in production")
+	// Output:
+	// Use NewPostgres with a real *pgxpool.Pool in production
+}
+
+// ExampleRegisterGobTypes demonstrates registering custom types so they can be
+// stored in sessions. Custom types must be registered before any session
+// read or write operations.
+func ExampleRegisterGobTypes() {
+	// Define a custom type you want to store in sessions.
+	type UserProfile struct {
+		ID   int
+		Name string
+		Role string
+	}
+
+	// Register the type with gob before using it in sessions.
+	session.RegisterGobTypes(UserProfile{})
+
+	// Now UserProfile values can safely be stored and retrieved:
+	// mgr.Put(r.Context(), "profile", UserProfile{ID: 1, Name: "Alice", Role: "admin"})
+}
+
+// ExampleManager_LoadAndSave demonstrates using LoadAndSave as middleware to
+// automatically manage session cookies across HTTP requests.
+func ExampleManager_LoadAndSave() {
+	mgr := session.NewMemory(session.Config{
+		Lifetime:   1 * time.Hour,
+		CookieName: "example-session",
+	})
+
+	// Use LoadAndSave as middleware in your router or handler chain.
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		// Count page views in the session.
+		views, _ := mgr.Get(r.Context(), "page_views").(int)
+		views++
+		mgr.Put(r.Context(), "page_views", views)
+		fmt.Fprintf(w, "Page views: %d", views)
+	})
+
+	// Wrap the entire mux with session middleware.
+	http.ListenAndServe(":8080", mgr.LoadAndSave(mux))
+}
+
+// ExampleManager_Put demonstrates storing values of various types in the
+// session using the context obtained from an HTTP request.
+func ExampleManager_Put() {
+	mgr := session.NewMemory(session.Config{})
+	_ = mgr // In a real handler, use mgr.LoadAndSave as middleware first.
+
+	// Inside an HTTP handler wrapped by LoadAndSave:
+	// mgr.Put(r.Context(), "user_id", 42)
+	// mgr.Put(r.Context(), "is_admin", true)
+	// mgr.Put(r.Context(), "preferences", map[string]string{"theme": "dark"})
+}
+
+// ExampleManager_Get demonstrates retrieving a value from the session with a
+// type assertion.
+func ExampleManager_Get() {
+	mgr := session.NewMemory(session.Config{})
+	_ = mgr // In a real handler, use mgr.LoadAndSave as middleware first.
+
+	// Inside an HTTP handler wrapped by LoadAndSave:
+	// val := mgr.Get(r.Context(), "user_id")
+	// if id, ok := val.(int); ok {
+	//     fmt.Fprintf(w, "User ID: %d", id)
+	// }
+}
+
+// ExampleManager_GetString demonstrates retrieving a string value from the
+// session.
+func ExampleManager_GetString() {
+	mgr := session.NewMemory(session.Config{})
+	_ = mgr // In a real handler, use mgr.LoadAndSave as middleware first.
+
+	// Inside an HTTP handler wrapped by LoadAndSave:
+	// mgr.Put(r.Context(), "username", "bob")
+	// username := mgr.GetString(r.Context(), "username")
+	// fmt.Fprintf(w, "Welcome, %s!", username)
+}
+
+// ExampleManager_PutHTTP demonstrates the convenience method for storing a
+// session value directly from an HTTP request, without manually extracting the
+// context.
+func ExampleManager_PutHTTP() {
+	mgr := session.NewMemory(session.Config{})
+	_ = mgr // In a real handler, use mgr.LoadAndSave as middleware first.
+
+	// Inside an HTTP handler wrapped by LoadAndSave:
+	// mgr.PutHTTP(r, "flash_message", "Record saved successfully")
+	//
+	// This is equivalent to:
+	// mgr.Put(r.Context(), "flash_message", "Record saved successfully")
+}
+
+// ExampleManager_Load demonstrates loading a session from a token outside the
+// standard middleware flow, such as in a WebSocket upgrade handler.
+func ExampleManager_Load() {
+	mgr := session.NewMemory(session.Config{})
+	_ = mgr
+
+	// When you have a session token (e.g., from a query parameter or custom
+	// header) and need to load the session outside the standard middleware:
+	// ctx := context.Background()
+	// sessionCtx, err := mgr.Load(ctx, token)
+	// if err != nil {
+	//     log.Printf("failed to load session: %v", err)
+	//     return
+	// }
+	// userID := mgr.Get(sessionCtx, "user_id")
+}
+
+// ExampleManager_Destroy demonstrates destroying a session, typically used for
+// logout functionality.
+func ExampleManager_Destroy() {
+	mgr := session.NewMemory(session.Config{})
+	_ = mgr
+
+	// Inside a logout handler wrapped by LoadAndSave:
+	// if err := mgr.Destroy(r.Context()); err != nil {
+	//     http.Error(w, "failed to destroy session", http.StatusInternalServerError)
+	//     return
+	// }
+	// http.Redirect(w, r, "/login", http.StatusSeeOther)
+}
+
+// ExampleManager_Inner demonstrates accessing the underlying SCS SessionManager
+// for advanced configuration or features not exposed by the Manager wrapper.
+func ExampleManager_Inner() {
+	mgr := session.NewMemory(session.Config{
+		CookieName: "advanced-session",
+	})
+
+	inner := mgr.Inner()
+	_ = inner
+
+	// Access advanced SCS features:
+	// inner.Cookie.HttpOnly = true
+	// inner.Cookie.Domain = "example.com"
+	// inner.IdleTimeout = 30 * time.Minute
+	// token := inner.Token(r.Context())
+}
+
+// ExampleNew demonstrates creating a Manager with a custom store
+// implementation. This is useful when you need a store backend not covered
+// by [session.NewMemory] or [session.NewPostgres].
+func ExampleNew() {
+	// Create a Manager with a custom store (e.g., a Redis store).
+	// store := redisstore.New(redisClient)
+	// mgr := session.New(session.Config{
+	//     Lifetime:       6 * time.Hour,
+	//     CookieName:     "custom-store-session",
+	//     CookieSecure:   true,
+	//     CookieSameSite: http.SameSiteStrictMode,
+	// }, store)
+
+	// For demonstration, show how defaults are applied:
+	mgr := session.NewMemory(session.Config{})
+	inner := mgr.Inner()
+	fmt.Println(inner.Cookie.Name)
+	// Output: session
+}
+
+// ExampleConfig_withDefaults demonstrates how Config zero-values are
+// populated with sensible defaults.
+func ExampleConfig() {
+	// All zero-value fields receive defaults:
+	cfg := session.Config{}
+
+	// The constructors apply defaults internally, but you can inspect the
+	// resulting configuration via the underlying manager.
+	mgr := session.NewMemory(cfg)
+	inner := mgr.Inner()
+
+	fmt.Println("Lifetime:", inner.Lifetime)
+	fmt.Println("SameSite:", inner.Cookie.SameSite)
+	// Output:
+	// Lifetime: 24h0m0s
+	// SameSite: 2
+}
+
+// Example_contextFlow demonstrates the full lifecycle of session data across
+// multiple HTTP requests using a shared Manager.
+func Example_contextFlow() {
+	mgr := session.NewMemory(session.Config{
+		Lifetime:   30 * time.Minute,
+		CookieName: "lifecycle-demo",
+	})
+	_ = mgr
+
+	// Request 1 — store data:
+	// handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	//     mgr.Put(r.Context(), "cart_items", 3)
+	//     w.WriteHeader(http.StatusOK)
+	// })
+
+	// Request 2 — retrieve data (using the session cookie from request 1):
+	// retrieveHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	//     items := mgr.Get(r.Context(), "cart_items")
+	//     fmt.Fprintf(w, "Cart items: %v", items)
+	// })
+
+	// Request 3 — destroy session (logout):
+	// logoutHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	//     mgr.Destroy(r.Context())
+	//     http.Redirect(w, r, "/", http.StatusSeeOther)
+	// })
+}
+
+// Example_backgroundWorker demonstrates loading a session from a token in a
+// non-HTTP context, such as a background job or WebSocket handler.
+func Example_backgroundWorker() {
+	mgr := session.NewMemory(session.Config{})
+	_ = mgr
+
+	// In a background worker or WebSocket handler, load a session from a token:
+	// ctx := context.Background()
+	// sessionCtx, err := mgr.Load(ctx, sessionToken)
+	// if err != nil {
+	//     log.Fatal(err)
+	// }
+	// data := mgr.Get(sessionCtx, "background_job_state")
+}

--- a/session/session.go
+++ b/session/session.go
@@ -1,3 +1,50 @@
+// Package session provides HTTP session management for the gotchi framework,
+// wrapping the SCS (Secure Cookie Sessions) library with a simplified API. It
+// supports both in-memory and PostgreSQL-backed session stores, with sensible
+// defaults for cookie configuration and session lifetime.
+//
+// The package centers on the [Manager] type, which wraps an SCS SessionManager
+// and exposes methods for loading, saving, reading, and writing session data.
+// Managers are created via the [NewMemory] or [NewPostgres] constructor
+// functions, or the generic [New] function when a custom [scs.Store] is needed.
+//
+// # Quick Start
+//
+// Create an in-memory session manager and use it as HTTP middleware:
+//
+//	mgr := session.NewMemory(session.Config{
+//	    Lifetime:   12 * time.Hour,
+//	    CookieName: "myapp-session",
+//	})
+//
+//	// Wrap your handler with session middleware.
+//	handler := mgr.LoadAndSave(myHandler)
+//	http.ListenAndServe(":8080", handler)
+//
+// For production use with PostgreSQL:
+//
+//	pool, _ := pgxpool.New(ctx, databaseURL)
+//	mgr := session.NewPostgres(session.Config{}, pool, "sessions")
+//
+// # Storing and Retrieving Values
+//
+// Within a handler wrapped by [Manager.LoadAndSave], use the context to
+// interact with session data:
+//
+//	func myHandler(w http.ResponseWriter, r *http.Request) {
+//	    mgr.Put(r.Context(), "user_id", 42)
+//	    id := mgr.GetString(r.Context(), "user_id")
+//	}
+//
+// # Custom Types
+//
+// To store custom types in sessions, register them with gob before creating
+// the manager:
+//
+//	type UserSession struct{ Name string; Role string }
+//	session.RegisterGobTypes(UserSession{})
+//
+//	mgr := session.NewMemory(session.Config{})
 package session
 
 import (
@@ -12,16 +59,43 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
+// DefaultSessionKey is the default cookie name used when Config.CookieName is
+// not explicitly set.
 const DefaultSessionKey = "session"
 
+// Config holds the configuration options for a session Manager. Zero-value
+// fields are replaced with sensible defaults when passed to any constructor.
+//
+// Defaults applied by the package:
+//   - ExpiryInterval: 5 minutes
+//   - Lifetime:       24 hours
+//   - CookieName:     "session" (see [DefaultSessionKey])
+//   - CookieSecure:   false
+//   - CookieSameSite: [http.SameSiteLaxMode]
 type Config struct {
+	// ExpiryInterval controls how often the session store runs cleanup of
+	// expired sessions. Defaults to 5 minutes if zero or negative.
 	ExpiryInterval time.Duration
-	Lifetime       time.Duration
-	CookieName     string
-	CookieSecure   bool
+
+	// Lifetime is the maximum duration a session remains valid. Defaults to
+	// 24 hours if zero or negative.
+	Lifetime time.Duration
+
+	// CookieName is the name of the HTTP cookie that holds the session token.
+	// Defaults to "session" if empty.
+	CookieName string
+
+	// CookieSecure sets the Secure attribute on the session cookie. When true,
+	// the cookie is only sent over HTTPS connections. Defaults to false.
+	CookieSecure bool
+
+	// CookieSameSite sets the SameSite attribute on the session cookie.
+	// Defaults to [http.SameSiteLaxMode] if zero.
 	CookieSameSite http.SameSite
 }
 
+// withDefaults returns a copy of the Config with zero-value fields replaced by
+// their default values. The original Config is not modified.
 func (c Config) withDefaults() Config {
 	cfg := c
 	if cfg.ExpiryInterval <= 0 {
@@ -39,16 +113,36 @@ func (c Config) withDefaults() Config {
 	return cfg
 }
 
+// Manager wraps an SCS SessionManager and provides a simplified API for HTTP
+// session management. Use one of the constructor functions ([New], [NewMemory],
+// or [NewPostgres]) to create a Manager instance.
 type Manager struct {
 	sessionManager *scs.SessionManager
 }
 
+// RegisterGobTypes registers one or more custom types with the gob encoding
+// package. This is required before storing non-primitive types (structs,
+// maps, slices of custom types, etc.) in session data. Call this function
+// before creating a Manager and before any session read/write operations.
+//
+// For example, to register a custom struct for session storage:
+//
+//	type CartItem struct {
+//	    ProductID int
+//	    Quantity  int
+//	}
+//	session.RegisterGobTypes(CartItem{})
 func RegisterGobTypes(values ...any) {
 	for _, value := range values {
 		gob.Register(value)
 	}
 }
 
+// New creates a new Manager with the provided Config and a custom SCS Store
+// implementation. This is the most flexible constructor, allowing use of any
+// store that implements the [scs.Store] interface.
+//
+// Zero-value fields in cfg are replaced with defaults (see [Config]).
 func New(cfg Config, store scs.Store) *Manager {
 	c := cfg.withDefaults()
 	sm := scs.New()
@@ -61,12 +155,26 @@ func New(cfg Config, store scs.Store) *Manager {
 	return &Manager{sessionManager: sm}
 }
 
+// NewMemory creates a new Manager backed by an in-memory store. Sessions are
+// held in process memory and are lost when the process restarts. This
+// constructor is suitable for development and testing, or for applications
+// where session persistence across restarts is not required.
+//
+// Zero-value fields in cfg are replaced with defaults (see [Config]).
 func NewMemory(cfg Config) *Manager {
 	c := cfg.withDefaults()
 	store := memstore.NewWithCleanupInterval(c.ExpiryInterval)
 	return New(c, store)
 }
 
+// NewPostgres creates a new Manager backed by a PostgreSQL store using the
+// provided connection pool. Sessions persist across process restarts, making
+// this suitable for production deployments.
+//
+// The tableName parameter specifies the database table used for session
+// storage. If tableName is empty, the pgxstore default table name is used.
+//
+// Zero-value fields in cfg are replaced with defaults (see [Config]).
 func NewPostgres(cfg Config, pool *pgxpool.Pool, tableName string) *Manager {
 	c := cfg.withDefaults()
 	storeCfg := pgxstore.Config{CleanUpInterval: c.ExpiryInterval}
@@ -77,34 +185,68 @@ func NewPostgres(cfg Config, pool *pgxpool.Pool, tableName string) *Manager {
 	return New(c, store)
 }
 
+// LoadAndSave returns an HTTP handler that automatically loads session data
+// from the request cookie before passing it to next, and saves any modified
+// session data back to the response cookie afterward. This is the primary
+// middleware for enabling sessions in your HTTP handler chain.
+//
+// Typically used at the top of your middleware stack:
+//
+//	r := chi.NewRouter()
+//	r.Use(mgr.LoadAndSave)
 func (m *Manager) LoadAndSave(next http.Handler) http.Handler {
 	return m.sessionManager.LoadAndSave(next)
 }
 
+// Load retrieves session data associated with the given token and returns a
+// new context.Context carrying the session state. This is useful for loading
+// sessions outside of the standard middleware flow, such as in WebSocket
+// upgrade handlers or background workers that receive a session token.
 func (m *Manager) Load(ctx context.Context, token string) (context.Context, error) {
 	return m.sessionManager.Load(ctx, token)
 }
 
+// Get retrieves the value associated with key from the session in ctx. The
+// return type is any; the caller must type-assert the result. Returns nil if
+// the key does not exist in the session.
 func (m *Manager) Get(ctx context.Context, key string) any {
 	return m.sessionManager.Get(ctx, key)
 }
 
+// GetString retrieves the value associated with key from the session in ctx,
+// type-asserted to a string. Returns an empty string if the key does not exist
+// or the value is not a string.
 func (m *Manager) GetString(ctx context.Context, key string) string {
 	return m.sessionManager.GetString(ctx, key)
 }
 
+// Put stores a key-value pair in the session associated with ctx. The value
+// must be a type registered with gob if it is not a built-in type. See
+// [RegisterGobTypes] for registering custom types.
 func (m *Manager) Put(ctx context.Context, key string, value any) {
 	m.sessionManager.Put(ctx, key, value)
 }
 
+// PutHTTP stores a key-value pair in the session associated with the given
+// HTTP request's context. This is a convenience wrapper around [Manager.Put]
+// that extracts the context from the request, allowing a shorter call in HTTP
+// handlers:
+//
+//	mgr.PutHTTP(r, "flash", "Item saved")
 func (m *Manager) PutHTTP(r *http.Request, key string, value any) {
 	m.sessionManager.Put(r.Context(), key, value)
 }
 
+// Destroy deletes all session data associated with the context and expires the
+// session cookie. Use this to implement logout functionality. Returns an error
+// if the underlying store fails to remove the session data.
 func (m *Manager) Destroy(ctx context.Context) error {
 	return m.sessionManager.Destroy(ctx)
 }
 
+// Inner returns the underlying [scs.SessionManager] instance. Use this to
+// access advanced SCS features not exposed by the Manager wrapper, such as
+// token inspection, iteration over session keys, or custom cookie settings.
 func (m *Manager) Inner() *scs.SessionManager {
 	return m.sessionManager
 }

--- a/tenantctx/example_test.go
+++ b/tenantctx/example_test.go
@@ -1,0 +1,86 @@
+package tenantctx_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/kusold/gotchi/tenantctx"
+)
+
+func ExampleWithTenantID() {
+	id := uuid.MustParse("550e8400-e29b-41d4-a716-446655440000")
+	ctx := tenantctx.WithTenantID(context.Background(), id)
+
+	tenantID, ok := tenantctx.TenantIDString(ctx)
+	fmt.Println(ok)
+	fmt.Println(tenantID)
+	// Output:
+	// true
+	// 550e8400-e29b-41d4-a716-446655440000
+}
+
+func ExampleWithTenantIDString() {
+	ctx := tenantctx.WithTenantIDString(context.Background(), "acme-corp")
+
+	tenantID, ok := tenantctx.TenantIDString(ctx)
+	fmt.Println(ok)
+	fmt.Println(tenantID)
+	// Output:
+	// true
+	// acme-corp
+}
+
+func ExampleWithSystemTenant() {
+	ctx := tenantctx.WithSystemTenant(context.Background())
+
+	fmt.Println(tenantctx.IsSystemTenant(ctx))
+
+	tenantID, ok := tenantctx.TenantIDString(ctx)
+	fmt.Println(ok)
+	fmt.Println(tenantID)
+	// Output:
+	// true
+	// true
+	// ADMIN_SYSTEM
+}
+
+func ExampleTenantID() {
+	id := uuid.MustParse("550e8400-e29b-41d4-a716-446655440000")
+	ctx := tenantctx.WithTenantID(context.Background(), id)
+
+	parsed, ok := tenantctx.TenantID(ctx)
+	fmt.Println(ok)
+	fmt.Println(parsed == id)
+	// Output:
+	// true
+	// true
+}
+
+func ExampleTenantIDString_missing() {
+	ctx := context.Background()
+
+	_, ok := tenantctx.TenantIDString(ctx)
+	fmt.Println(ok)
+	// Output:
+	// false
+}
+
+func ExampleIsSystemTenant() {
+	// A regular tenant context is not the system tenant.
+	id := uuid.New()
+	ctx := tenantctx.WithTenantID(context.Background(), id)
+	fmt.Println(tenantctx.IsSystemTenant(ctx))
+
+	// A system tenant context is recognized.
+	sysCtx := tenantctx.WithSystemTenant(context.Background())
+	fmt.Println(tenantctx.IsSystemTenant(sysCtx))
+
+	// A context with no tenant ID is not the system tenant.
+	emptyCtx := context.Background()
+	fmt.Println(tenantctx.IsSystemTenant(emptyCtx))
+	// Output:
+	// false
+	// true
+	// false
+}

--- a/tenantctx/tenantctx.go
+++ b/tenantctx/tenantctx.go
@@ -1,3 +1,29 @@
+// Package tenantctx provides utilities for storing and retrieving tenant
+// identifiers within a [context.Context]. It is designed for use in
+// multi-tenant applications where each request must be associated with a
+// specific tenant.
+//
+// Tenant IDs are stored internally as strings, but convenience functions are
+// provided for working with [github.com/google/uuid.UUID] values. The package
+// also defines a special [SystemTenant] constant that represents an
+// administrative system-level tenant.
+//
+// # Setting a Tenant ID
+//
+// Use [WithTenantID] to store a UUID-based tenant ID, or [WithTenantIDString]
+// for an arbitrary string value. [WithSystemTenant] is a shorthand that sets
+// the tenant to [SystemTenant].
+//
+// # Retrieving a Tenant ID
+//
+// Use [TenantIDString] to retrieve the raw string value, or [TenantID] to
+// parse it back into a UUID. Both functions return a boolean indicating whether
+// a valid tenant ID was present in the context.
+//
+// # Checking for System Tenant
+//
+// Use [IsSystemTenant] to check whether the context carries the system tenant
+// identifier. This is useful for authorizing administrative operations.
 package tenantctx
 
 import (
@@ -6,24 +32,40 @@ import (
 	"github.com/google/uuid"
 )
 
+// SystemTenant is the tenant identifier used for administrative system-level
+// operations. It is not a valid UUID and will cause [TenantID] to return
+// false; use [TenantIDString] or [IsSystemTenant] instead when working with
+// the system tenant.
 const SystemTenant = "ADMIN_SYSTEM"
 
 type tenantContextKey struct{}
 
 var tenantKey = tenantContextKey{}
 
+// WithTenantID returns a new [context.Context] with the given tenant ID stored
+// as its string representation. The UUID is converted to a string internally
+// so that both [TenantIDString] and [TenantID] can retrieve it.
 func WithTenantID(ctx context.Context, tenantID uuid.UUID) context.Context {
 	return context.WithValue(ctx, tenantKey, tenantID.String())
 }
 
+// WithTenantIDString returns a new [context.Context] with the given tenant ID
+// string. This is useful when the tenant ID is already in string form, such as
+// when parsing from a request header or a JWT claim.
 func WithTenantIDString(ctx context.Context, tenantID string) context.Context {
 	return context.WithValue(ctx, tenantKey, tenantID)
 }
 
+// WithSystemTenant returns a new [context.Context] with the tenant ID set to
+// [SystemTenant]. This is a convenience wrapper around [WithTenantIDString]
+// for administrative contexts.
 func WithSystemTenant(ctx context.Context) context.Context {
 	return WithTenantIDString(ctx, SystemTenant)
 }
 
+// TenantIDString retrieves the tenant ID as a string from the given context.
+// It returns the tenant ID and true if a non-empty tenant ID is present, or an
+// empty string and false if the tenant ID is missing or empty.
 func TenantIDString(ctx context.Context) (string, bool) {
 	tenantID, ok := ctx.Value(tenantKey).(string)
 	if !ok || tenantID == "" {
@@ -32,6 +74,11 @@ func TenantIDString(ctx context.Context) (string, bool) {
 	return tenantID, true
 }
 
+// TenantID retrieves the tenant ID as a [uuid.UUID] from the given context.
+// It returns the parsed UUID and true if a valid UUID tenant ID is present, or
+// a zero UUID and false if the tenant ID is missing, empty, or not a valid
+// UUID. Note that [SystemTenant] is not a valid UUID and will cause this
+// function to return false; use [TenantIDString] for the raw value.
 func TenantID(ctx context.Context) (uuid.UUID, bool) {
 	tenantID, ok := TenantIDString(ctx)
 	if !ok {
@@ -44,6 +91,9 @@ func TenantID(ctx context.Context) (uuid.UUID, bool) {
 	return parsed, true
 }
 
+// IsSystemTenant reports whether the context carries the [SystemTenant]
+// identifier. It returns false if no tenant ID is present in the context or if
+// the tenant ID is any value other than [SystemTenant].
 func IsSystemTenant(ctx context.Context) bool {
 	tenantID, ok := TenantIDString(ctx)
 	if !ok {


### PR DESCRIPTION
## Summary
- Add package-level doc comments with usage examples for all 9 public packages (app, auth, db, observability, openapi, session, tenantctx, migrations, internal/scaffold)
- Document every exported type, function, method, constant, and variable with godoc-compatible comments
- Add 23 `Example*` test functions for the session and tenantctx packages demonstrating typical API usage

## Details

Every package now has:
- A `// Package <name>` doc comment describing purpose, key concepts, and quick-start code
- Doc comments on all exported symbols following Go conventions (first sentence starts with the symbol name)
- Field-level documentation on all exported struct fields
- Interface method documentation

| Package | Package doc | Symbol docs | Examples |
|---------|-----------|-------------|----------|
| `app` | Yes | All types, methods, config fields | — |
| `auth` | Yes | 7 files, all exported symbols | — |
| `db` | Yes | All types, methods | — |
| `observability` | Yes | All types, methods, config fields | — |
| `openapi` | Yes | All types, methods, fields | — |
| `session` | Yes | All types, methods, fields | 17 examples |
| `tenantctx` | Yes | All functions, constants | 6 examples |
| `migrations` | Yes | Core(), Auth() | — |
| `internal/scaffold` | Yes (pre-existing) | All types, functions | — |

## Test plan
- [x] `go vet ./...` passes with no warnings
- [x] `go doc` renders correctly for all packages
- [x] All non-Docker-dependent tests pass (including new Example tests)
- [ ] Visual review of `go doc` output for accuracy and completeness