### PR TITLE
feat(cli): add gotchi migrations export command

### DIFF
--- a/cmd/gotchi/main.go
+++ b/cmd/gotchi/main.go
@@ -1,14 +1,17 @@
 package main
 
 import (
+	"crypto/sha256"
 	"errors"
 	"flag"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/kusold/gotchi/internal/scaffold"
+	"github.com/kusold/gotchi/migrations"
 )
 
 func main() {
@@ -25,6 +28,8 @@ func main() {
 		err = runAdd(os.Args[2:])
 	case "doctor":
 		err = runDoctor(os.Args[2:])
+	case "migrations":
+		err = runMigrations(os.Args[2:])
 	case "help", "-h", "--help":
 		printUsage()
 		return
@@ -167,4 +172,106 @@ func printUsage() {
 	fmt.Println("  gotchi init <app-name> [--module <module>] [--output <dir>]")
 	fmt.Println("  gotchi add feature <name>")
 	fmt.Println("  gotchi doctor [--root <project-dir>]")
+	fmt.Println("  gotchi migrations export [--output <dir>] [--force|--skip] [--component core|auth|all]")
+}
+
+func runMigrations(args []string) error {
+	if len(args) < 1 {
+		return errors.New("usage: gotchi migrations <subcommand>\n\nsubcommands:\n  export  Copy embedded migration SQL files to the local filesystem")
+	}
+	switch args[0] {
+	case "export":
+		return runMigrationsExport(args[1:])
+	default:
+		return fmt.Errorf("unknown migrations subcommand: %s", args[0])
+	}
+}
+
+func runMigrationsExport(args []string) error {
+	flags := flag.NewFlagSet("migrations export", flag.ContinueOnError)
+	outputDir := flags.String("output", "migrations/gotchi", "Target directory for exported migration files")
+	force := flags.Bool("force", false, "Overwrite existing files without prompting")
+	skip := flags.Bool("skip", false, "Skip existing files without prompting")
+	component := flags.String("component", "all", "Which migrations to export: core, auth, or all")
+	flags.StringVar(outputDir, "o", *outputDir, "Shorthand for --output")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+
+	if *force && *skip {
+		return errors.New("cannot use both --force and --skip")
+	}
+
+	switch *component {
+	case "core", "auth", "all":
+		// valid
+	default:
+		return fmt.Errorf("invalid --component value %q; must be core, auth, or all", *component)
+	}
+
+	type migrationSource struct {
+		name string
+		fsys fs.FS
+	}
+	var sources []migrationSource
+	if *component == "all" || *component == "core" {
+		sources = append(sources, migrationSource{"core", migrations.Core()})
+	}
+	if *component == "all" || *component == "auth" {
+		sources = append(sources, migrationSource{"auth", migrations.Auth()})
+	}
+
+	var copied, skipped, unchanged int
+
+	for _, src := range sources {
+		entries, err := fs.ReadDir(src.fsys, ".")
+		if err != nil {
+			return fmt.Errorf("reading embedded %s migrations: %w", src.name, err)
+		}
+
+		targetDir := filepath.Join(*outputDir, src.name)
+		if err := os.MkdirAll(targetDir, 0o755); err != nil {
+			return fmt.Errorf("creating directory %s: %w", targetDir, err)
+		}
+
+		for _, entry := range entries {
+			if entry.IsDir() {
+				continue
+			}
+
+			embeddedContent, err := fs.ReadFile(src.fsys, entry.Name())
+			if err != nil {
+				return fmt.Errorf("reading embedded file %s/%s: %w", src.name, entry.Name(), err)
+			}
+
+			targetPath := filepath.Join(targetDir, entry.Name())
+
+			existingContent, err := os.ReadFile(targetPath)
+			if err == nil {
+				// File already exists
+				if sha256.Sum256(existingContent) == sha256.Sum256(embeddedContent) {
+					unchanged++
+					continue
+				}
+
+				if *skip {
+					skipped++
+					continue
+				}
+
+				if !*force {
+					return fmt.Errorf("file %s already exists with different content (use --force to overwrite or --skip to skip)", targetPath)
+				}
+				// --force: fall through to overwrite
+			}
+
+			if err := os.WriteFile(targetPath, embeddedContent, 0o644); err != nil {
+				return fmt.Errorf("writing %s: %w", targetPath, err)
+			}
+			copied++
+		}
+	}
+
+	fmt.Printf("migrations export complete: %d copied, %d skipped, %d unchanged\n", copied, skipped, unchanged)
+	return nil
 }

--- a/cmd/gotchi/main_test.go
+++ b/cmd/gotchi/main_test.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/kusold/gotchi/migrations"
 )
 
 // ============================================================================
@@ -367,6 +370,231 @@ func TestRunDoctorInvalidFlag(t *testing.T) {
 	err := runDoctor([]string{"--invalid"})
 	if err == nil {
 		t.Fatal("expected error for invalid flag")
+	}
+}
+
+// ============================================================================
+// runMigrations tests
+// ============================================================================
+
+func TestRunMigrationsNoArgs(t *testing.T) {
+	err := runMigrations([]string{})
+	if err == nil {
+		t.Fatal("expected error for no args")
+	}
+	if !strings.Contains(err.Error(), "usage:") {
+		t.Errorf("expected usage error, got: %v", err)
+	}
+}
+
+func TestRunMigrationsUnknownSubcommand(t *testing.T) {
+	err := runMigrations([]string{"import"})
+	if err == nil {
+		t.Fatal("expected error for unknown subcommand")
+	}
+	if !strings.Contains(err.Error(), "unknown migrations subcommand") {
+		t.Errorf("expected unknown subcommand error, got: %v", err)
+	}
+}
+
+// ============================================================================
+// runMigrationsExport tests
+// ============================================================================
+
+func TestMigrationsExportAll(t *testing.T) {
+	tmp := t.TempDir()
+	err := runMigrationsExport([]string{"--output", tmp})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should have core/ and auth/ subdirectories with SQL files
+	coreFiles, _ := filepath.Glob(filepath.Join(tmp, "core", "*.sql"))
+	authFiles, _ := filepath.Glob(filepath.Join(tmp, "auth", "*.sql"))
+	if len(coreFiles) == 0 {
+		t.Error("expected at least one core migration file")
+	}
+	if len(authFiles) == 0 {
+		t.Error("expected at least one auth migration file")
+	}
+}
+
+func TestMigrationsExportComponentCore(t *testing.T) {
+	tmp := t.TempDir()
+	err := runMigrationsExport([]string{"--output", tmp, "--component", "core"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	coreFiles, _ := filepath.Glob(filepath.Join(tmp, "core", "*.sql"))
+	if len(coreFiles) == 0 {
+		t.Error("expected core migration files")
+	}
+
+	// auth directory should not exist
+	if _, err := os.Stat(filepath.Join(tmp, "auth")); !os.IsNotExist(err) {
+		t.Error("auth directory should not exist when --component=core")
+	}
+}
+
+func TestMigrationsExportComponentAuth(t *testing.T) {
+	tmp := t.TempDir()
+	err := runMigrationsExport([]string{"--output", tmp, "--component", "auth"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	authFiles, _ := filepath.Glob(filepath.Join(tmp, "auth", "*.sql"))
+	if len(authFiles) == 0 {
+		t.Error("expected auth migration files")
+	}
+
+	// core directory should not exist
+	if _, err := os.Stat(filepath.Join(tmp, "core")); !os.IsNotExist(err) {
+		t.Error("core directory should not exist when --component=auth")
+	}
+}
+
+func TestMigrationsExportIdempotentUnchanged(t *testing.T) {
+	tmp := t.TempDir()
+
+	// First export
+	if err := runMigrationsExport([]string{"--output", tmp}); err != nil {
+		t.Fatalf("first export: %v", err)
+	}
+
+	// Second export should succeed and report unchanged
+	if err := runMigrationsExport([]string{"--output", tmp}); err != nil {
+		t.Fatalf("second export: %v", err)
+	}
+}
+
+func TestMigrationsExportConflictErrors(t *testing.T) {
+	tmp := t.TempDir()
+
+	// Create a file that will conflict
+	coreDir := filepath.Join(tmp, "core")
+	if err := os.MkdirAll(coreDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	conflictPath := filepath.Join(coreDir, "20260221160000_core.sql")
+	if err := os.WriteFile(conflictPath, []byte("different content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := runMigrationsExport([]string{"--output", tmp})
+	if err == nil {
+		t.Fatal("expected error for conflicting file")
+	}
+	if !strings.Contains(err.Error(), "already exists with different content") {
+		t.Errorf("expected conflict error, got: %v", err)
+	}
+}
+
+func TestMigrationsExportForceOverwrites(t *testing.T) {
+	tmp := t.TempDir()
+
+	// Create conflicting file
+	coreDir := filepath.Join(tmp, "core")
+	if err := os.MkdirAll(coreDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	conflictPath := filepath.Join(coreDir, "20260221160000_core.sql")
+	if err := os.WriteFile(conflictPath, []byte("old content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := runMigrationsExport([]string{"--output", tmp, "--force"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(conflictPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) == "old content" {
+		t.Error("expected file to be overwritten with embedded content")
+	}
+}
+
+func TestMigrationsExportSkipConflicts(t *testing.T) {
+	tmp := t.TempDir()
+
+	// Create conflicting file
+	coreDir := filepath.Join(tmp, "core")
+	if err := os.MkdirAll(coreDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	conflictPath := filepath.Join(coreDir, "20260221160000_core.sql")
+	if err := os.WriteFile(conflictPath, []byte("old content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := runMigrationsExport([]string{"--output", tmp, "--skip"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(conflictPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "old content" {
+		t.Error("expected conflicting file to be preserved when using --skip")
+	}
+}
+
+func TestMigrationsExportForceAndSkipRejected(t *testing.T) {
+	err := runMigrationsExport([]string{"--force", "--skip"})
+	if err == nil {
+		t.Fatal("expected error for --force and --skip together")
+	}
+	if !strings.Contains(err.Error(), "cannot use both --force and --skip") {
+		t.Errorf("expected mutual exclusion error, got: %v", err)
+	}
+}
+
+func TestMigrationsExportInvalidComponent(t *testing.T) {
+	err := runMigrationsExport([]string{"--component", "bogus"})
+	if err == nil {
+		t.Fatal("expected error for invalid component")
+	}
+	if !strings.Contains(err.Error(), "invalid --component value") {
+		t.Errorf("expected invalid component error, got: %v", err)
+	}
+}
+
+func TestMigrationsExportShortOutputFlag(t *testing.T) {
+	tmp := t.TempDir()
+	err := runMigrationsExport([]string{"-o", tmp})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	coreFiles, _ := filepath.Glob(filepath.Join(tmp, "core", "*.sql"))
+	if len(coreFiles) == 0 {
+		t.Error("expected migration files with -o shorthand")
+	}
+}
+
+func TestMigrationsExportOutputMatchesEmbedded(t *testing.T) {
+	tmp := t.TempDir()
+	if err := runMigrationsExport([]string{"--output", tmp, "--component", "core"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Read the embedded content directly and compare with exported file
+	embedded, err := fs.ReadFile(migrations.Core(), "20260221160000_core.sql")
+	if err != nil {
+		t.Fatalf("reading embedded file: %v", err)
+	}
+	exported, err := os.ReadFile(filepath.Join(tmp, "core", "20260221160000_core.sql"))
+	if err != nil {
+		t.Fatalf("reading exported file: %v", err)
+	}
+	if string(embedded) != string(exported) {
+		t.Error("exported file content does not match embedded content")
 	}
 }
 

--- a/cmd/gotchi/main_test.go
+++ b/cmd/gotchi/main_test.go
@@ -469,18 +469,25 @@ func TestMigrationsExportIdempotentUnchanged(t *testing.T) {
 	}
 }
 
-func TestMigrationsExportConflictErrors(t *testing.T) {
-	tmp := t.TempDir()
-
-	// Create a file that will conflict
-	coreDir := filepath.Join(tmp, "core")
+// createConflict sets up a temp directory with a core migration file containing
+// content that differs from the embedded version, returning the temp dir and the
+// conflict file path.
+func createConflict(t *testing.T) (tmpDir string, conflictPath string) {
+	t.Helper()
+	tmpDir = t.TempDir()
+	coreDir := filepath.Join(tmpDir, "core")
 	if err := os.MkdirAll(coreDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	conflictPath := filepath.Join(coreDir, "20260221160000_core.sql")
+	conflictPath = filepath.Join(coreDir, "20260221160000_core.sql")
 	if err := os.WriteFile(conflictPath, []byte("different content"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	return tmpDir, conflictPath
+}
+
+func TestMigrationsExportConflictErrors(t *testing.T) {
+	tmp, _ := createConflict(t)
 
 	err := runMigrationsExport([]string{"--output", tmp})
 	if err == nil {
@@ -492,17 +499,7 @@ func TestMigrationsExportConflictErrors(t *testing.T) {
 }
 
 func TestMigrationsExportForceOverwrites(t *testing.T) {
-	tmp := t.TempDir()
-
-	// Create conflicting file
-	coreDir := filepath.Join(tmp, "core")
-	if err := os.MkdirAll(coreDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	conflictPath := filepath.Join(coreDir, "20260221160000_core.sql")
-	if err := os.WriteFile(conflictPath, []byte("old content"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	tmp, conflictPath := createConflict(t)
 
 	err := runMigrationsExport([]string{"--output", tmp, "--force"})
 	if err != nil {
@@ -513,23 +510,13 @@ func TestMigrationsExportForceOverwrites(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(data) == "old content" {
+	if string(data) == "different content" {
 		t.Error("expected file to be overwritten with embedded content")
 	}
 }
 
 func TestMigrationsExportSkipConflicts(t *testing.T) {
-	tmp := t.TempDir()
-
-	// Create conflicting file
-	coreDir := filepath.Join(tmp, "core")
-	if err := os.MkdirAll(coreDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	conflictPath := filepath.Join(coreDir, "20260221160000_core.sql")
-	if err := os.WriteFile(conflictPath, []byte("old content"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	tmp, conflictPath := createConflict(t)
 
 	err := runMigrationsExport([]string{"--output", tmp, "--skip"})
 	if err != nil {
@@ -540,7 +527,7 @@ func TestMigrationsExportSkipConflicts(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(data) != "old content" {
+	if string(data) != "different content" {
 		t.Error("expected conflicting file to be preserved when using --skip")
 	}
 }


### PR DESCRIPTION
## Summary
- Adds `gotchi migrations export` subcommand to copy embedded migration SQL files (core/auth) into the consuming project's filesystem
- Supports `--output`/`-o`, `--force`, `--skip`, and `--component` flags as specified in the Vikunja task
- Enables external tooling like sqlc to inspect gotchi's schema without a live database connection

## Test plan
- [x] `go build ./cmd/gotchi/` compiles cleanly
- [x] `go test ./cmd/gotchi/` passes
- [x] `gotchi migrations export` copies all 3 migration files to `migrations/gotchi/`
- [x] Re-running reports `0 copied, 0 skipped, 3 unchanged` (idempotent)
- [x] `--component core` exports only the core migration
- [x] Conflicting files error with helpful message; `--force` overwrites, `--skip` skips
- [x] `--force` and `--skip` together is rejected
- [x] Invalid `--component` value is rejected