### PR TITLE
feat(auth): add OIDC logout endpoint with RP-initiated logout

### DIFF
--- a/auth/config.go
+++ b/auth/config.go
@@ -44,6 +44,12 @@ type Config struct {
 	// TenantSelectPath is the URL path for the API endpoint to select a tenant.
 	// Defaults to [DefaultTenantSelectPath].
 	TenantSelectPath string
+	// LogoutPath is the URL path for the OIDC logout endpoint.
+	// Defaults to [DefaultLogoutPath].
+	LogoutPath string
+	// PostLogoutRedirect is the URL to redirect to after logout.
+	// Defaults to [DefaultPostLogoutRedirect].
+	PostLogoutRedirect string
 	// StateCookieName is the name of the cookie holding the OIDC state parameter.
 	// Defaults to [DefaultStateCookieName].
 	StateCookieName string
@@ -77,6 +83,12 @@ func (c Config) withDefaults() Config {
 	}
 	if cfg.TenantSelectPath == "" {
 		cfg.TenantSelectPath = DefaultTenantSelectPath
+	}
+	if cfg.LogoutPath == "" {
+		cfg.LogoutPath = DefaultLogoutPath
+	}
+	if cfg.PostLogoutRedirect == "" {
+		cfg.PostLogoutRedirect = DefaultPostLogoutRedirect
 	}
 	if cfg.StateCookieName == "" {
 		cfg.StateCookieName = DefaultStateCookieName

--- a/auth/config_test.go
+++ b/auth/config_test.go
@@ -16,6 +16,8 @@ func assertDefaultConfig(t *testing.T, cfg Config) {
 	assert.Equal(t, DefaultCallbackPath, cfg.CallbackPath, "CallbackPath should default to DefaultCallbackPath")
 	assert.Equal(t, DefaultTenantsPath, cfg.TenantsPath, "TenantsPath should default to DefaultTenantsPath")
 	assert.Equal(t, DefaultTenantSelectPath, cfg.TenantSelectPath, "TenantSelectPath should default to DefaultTenantSelectPath")
+	assert.Equal(t, DefaultLogoutPath, cfg.LogoutPath, "LogoutPath should default to DefaultLogoutPath")
+	assert.Equal(t, DefaultPostLogoutRedirect, cfg.PostLogoutRedirect, "PostLogoutRedirect should default to DefaultPostLogoutRedirect")
 	assert.Equal(t, DefaultStateCookieName, cfg.StateCookieName, "StateCookieName should default to DefaultStateCookieName")
 	assert.NotNil(t, cfg.CookieSecure, "CookieSecure should not be nil")
 	assert.True(t, *cfg.CookieSecure, "CookieSecure should default to true")
@@ -47,6 +49,8 @@ func TestConfig_WithDefaults_PreservesProvidedValues(t *testing.T) {
 		CallbackPath:      "/custom/callback",
 		TenantsPath:       "/custom/tenants/list",
 		TenantSelectPath:  "/custom/tenant/select",
+		LogoutPath:        "/custom/logout",
+		PostLogoutRedirect: "/custom/goodbye",
 		StateCookieName:   "custom_state",
 		CookieSecure:      &customSecure,
 	}.withDefaults()
@@ -64,6 +68,8 @@ func TestConfig_WithDefaults_PreservesProvidedValues(t *testing.T) {
 	assert.Equal(t, "/custom/callback", cfg.CallbackPath)
 	assert.Equal(t, "/custom/tenants/list", cfg.TenantsPath)
 	assert.Equal(t, "/custom/tenant/select", cfg.TenantSelectPath)
+	assert.Equal(t, "/custom/logout", cfg.LogoutPath)
+	assert.Equal(t, "/custom/goodbye", cfg.PostLogoutRedirect)
 	assert.Equal(t, "custom_state", cfg.StateCookieName)
 	assert.NotNil(t, cfg.CookieSecure)
 	assert.False(t, *cfg.CookieSecure)

--- a/auth/handler.go
+++ b/auth/handler.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
@@ -15,6 +16,8 @@ import (
 
 	"github.com/kusold/gotchi/session"
 )
+
+const idTokenKey = DefaultSessionKey + ".id_token"
 
 // OIDCHandler manages the OpenID Connect authentication flow including
 // authorization redirects, token exchange, user provisioning, and tenant
@@ -109,6 +112,8 @@ func (h *OIDCHandler) CallbackHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	rawIDToken, _ := token.Extra("id_token").(string)
+
 	idToken, err := h.oidc.VerifyIDToken(r.Context(), token)
 	if err != nil {
 		http.Error(w, "failed to verify id token", http.StatusUnauthorized)
@@ -179,6 +184,9 @@ func (h *OIDCHandler) CallbackHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	h.session.Put(r.Context(), h.cfg.SessionKey, claimsSession)
+	if rawIDToken != "" {
+		h.session.Put(r.Context(), idTokenKey, rawIDToken)
+	}
 
 	if claimsSession.ActiveTenantID == nil {
 		h.handleTenantSelectionRequired(w, r, memberships)
@@ -286,21 +294,26 @@ func (h *OIDCHandler) SelectTenantHandler(w http.ResponseWriter, r *http.Request
 // [Config.PostLogoutRedirect]. This ensures both the local session and
 // the provider-side session are terminated.
 func (h *OIDCHandler) LogoutHandler(w http.ResponseWriter, r *http.Request) {
+	rawIDToken, _ := h.session.Get(r.Context(), idTokenKey).(string)
+
 	if err := h.session.Destroy(r.Context()); err != nil {
 		http.Error(w, "failed to destroy session", http.StatusInternalServerError)
 		return
 	}
 
-	// Redirect to the provider's end_session_endpoint if available.
 	if endSession := h.oidc.EndSessionURL(); endSession != "" {
 		logoutURL, err := url.Parse(endSession)
 		if err == nil {
 			q := logoutURL.Query()
 			q.Set("post_logout_redirect_uri", h.cfg.PostLogoutRedirect)
+			if rawIDToken != "" {
+				q.Set("id_token_hint", rawIDToken)
+			}
 			logoutURL.RawQuery = q.Encode()
 			http.Redirect(w, r, logoutURL.String(), http.StatusSeeOther)
 			return
 		}
+		slog.Warn("failed to parse end_session_endpoint", "url", endSession, "err", err)
 	}
 
 	http.Redirect(w, r, h.cfg.PostLogoutRedirect, http.StatusSeeOther)

--- a/auth/handler.go
+++ b/auth/handler.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -62,11 +63,13 @@ func NewOIDCHandlerWithAuthenticator(cfg Config, authenticator *OIDCAuthenticato
 //   - GET [Config.CallbackPath] — handles the OIDC callback and token exchange
 //   - GET [Config.TenantsPath] — lists the user's tenant memberships (JSON)
 //   - POST [Config.TenantSelectPath] — selects an active tenant (JSON body)
+//   - POST [Config.LogoutPath] — destroys the session and redirects to provider logout
 func (h *OIDCHandler) RegisterRoutes(r chi.Router) {
 	r.Get(h.cfg.AuthorizePath, h.AuthorizeHandler)
 	r.Get(h.cfg.CallbackPath, h.CallbackHandler)
 	r.Get(h.cfg.TenantsPath, h.ListTenantsHandler)
 	r.Post(h.cfg.TenantSelectPath, h.SelectTenantHandler)
+	r.Post(h.cfg.LogoutPath, h.LogoutHandler)
 }
 
 // AuthorizeHandler initiates the OIDC authorization code flow by generating
@@ -276,6 +279,31 @@ func (h *OIDCHandler) SelectTenantHandler(w http.ResponseWriter, r *http.Request
 	claims.ActiveTenantID = &tenantID
 	h.session.Put(r.Context(), h.cfg.SessionKey, claims)
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// LogoutHandler destroys the current session and redirects to the OIDC
+// provider's end_session_endpoint if available, otherwise to
+// [Config.PostLogoutRedirect]. This ensures both the local session and
+// the provider-side session are terminated.
+func (h *OIDCHandler) LogoutHandler(w http.ResponseWriter, r *http.Request) {
+	if err := h.session.Destroy(r.Context()); err != nil {
+		http.Error(w, "failed to destroy session", http.StatusInternalServerError)
+		return
+	}
+
+	// Redirect to the provider's end_session_endpoint if available.
+	if endSession := h.oidc.EndSessionURL(); endSession != "" {
+		logoutURL, err := url.Parse(endSession)
+		if err == nil {
+			q := logoutURL.Query()
+			q.Set("post_logout_redirect_uri", h.cfg.PostLogoutRedirect)
+			logoutURL.RawQuery = q.Encode()
+			http.Redirect(w, r, logoutURL.String(), http.StatusSeeOther)
+			return
+		}
+	}
+
+	http.Redirect(w, r, h.cfg.PostLogoutRedirect, http.StatusSeeOther)
 }
 
 func (h *OIDCHandler) handleTenantSelectionRequired(w http.ResponseWriter, r *http.Request, memberships []Membership) {

--- a/auth/logout_test.go
+++ b/auth/logout_test.go
@@ -1,12 +1,19 @@
 package auth
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
+	"github.com/alexedwards/scs/v2"
+	"github.com/alexedwards/scs/v2/memstore"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kusold/gotchi/session"
 )
 
 func TestLogoutHandler_DestroysSession(t *testing.T) {
@@ -125,6 +132,137 @@ func TestOIDCAuthenticator_EndSessionURL(t *testing.T) {
 			assert.Equal(t, tt.want, auth.EndSessionURL())
 		})
 	}
+}
+
+func TestLogoutHandler_SessionDestroyError(t *testing.T) {
+	inner := memstore.NewWithCleanupInterval(5 * time.Minute)
+	failingStore := &failingDeleteStore{inner: inner}
+	sessionMgr := session.New(session.Config{}, failingStore)
+	session.RegisterGobTypes(SessionClaims{})
+
+	handler := NewOIDCHandlerWithAuthenticator(
+		Config{PostLogoutRedirect: "/goodbye"},
+		&OIDCAuthenticator{issuerURL: "https://example.com"},
+		sessionMgr,
+		&mockIdentityStore{},
+	)
+
+	tenantID := uuid.New()
+	cookies := withSessionClaims(t, sessionMgr, SessionClaims{
+		Authenticated:  true,
+		UserID:         uuid.New(),
+		ActiveTenantID: &tenantID,
+	})
+
+	chain := sessionMgr.LoadAndSave(http.HandlerFunc(handler.LogoutHandler))
+
+	req := httptest.NewRequest("POST", "/oidc/logout", nil)
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	rec := httptest.NewRecorder()
+	chain.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+	assert.Contains(t, rec.Body.String(), "failed to destroy session")
+}
+
+func TestLogoutHandler_MalformedEndSessionEndpoint(t *testing.T) {
+	sessionMgr := setupSessionManager(t)
+
+	authenticator := &OIDCAuthenticator{
+		issuerURL:          "https://example.com",
+		endSessionEndpoint: "https://example.com/\x00bad",
+	}
+
+	handler := NewOIDCHandlerWithAuthenticator(
+		Config{PostLogoutRedirect: "/goodbye"},
+		authenticator,
+		sessionMgr,
+		&mockIdentityStore{},
+	)
+
+	chain := sessionMgr.LoadAndSave(http.HandlerFunc(handler.LogoutHandler))
+
+	req := httptest.NewRequest("POST", "/oidc/logout", nil)
+	rec := httptest.NewRecorder()
+	chain.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusSeeOther, rec.Code)
+	assert.Equal(t, "/goodbye", rec.Header().Get("Location"))
+}
+
+func TestLogoutHandler_PassesIDTokenHint(t *testing.T) {
+	sessionMgr := setupSessionManager(t)
+
+	authenticator := &OIDCAuthenticator{
+		issuerURL:          "https://example.com",
+		endSessionEndpoint: "https://example.com/session/end",
+	}
+
+	handler := NewOIDCHandlerWithAuthenticator(
+		Config{PostLogoutRedirect: "/goodbye"},
+		authenticator,
+		sessionMgr,
+		&mockIdentityStore{},
+	)
+
+	tenantID := uuid.New()
+	cookies := withSessionClaimsAndIDToken(t, sessionMgr, SessionClaims{
+		Authenticated:  true,
+		UserID:         uuid.New(),
+		ActiveTenantID: &tenantID,
+	}, "mock-raw-id-token")
+
+	chain := sessionMgr.LoadAndSave(http.HandlerFunc(handler.LogoutHandler))
+
+	req := httptest.NewRequest("POST", "/oidc/logout", nil)
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	rec := httptest.NewRecorder()
+	chain.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusSeeOther, rec.Code)
+	location := rec.Header().Get("Location")
+	assert.Contains(t, location, "https://example.com/session/end")
+	assert.Contains(t, location, "id_token_hint=mock-raw-id-token")
+	assert.Contains(t, location, "post_logout_redirect_uri=%2Fgoodbye")
+}
+
+type failingDeleteStore struct {
+	inner scs.Store
+}
+
+func (s *failingDeleteStore) Delete(_ string) error {
+	return fmt.Errorf("forced delete failure")
+}
+
+func (s *failingDeleteStore) Find(token string) ([]byte, bool, error) {
+	return s.inner.Find(token)
+}
+
+func (s *failingDeleteStore) Commit(token string, b []byte, expiry time.Time) error {
+	return s.inner.Commit(token, b, expiry)
+}
+
+func withSessionClaimsAndIDToken(t *testing.T, sessionMgr *session.Manager, claims SessionClaims, rawIDToken string) []*http.Cookie {
+	t.Helper()
+
+	setHandler := sessionMgr.LoadAndSave(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sessionMgr.Put(r.Context(), DefaultSessionKey, claims)
+		sessionMgr.Put(r.Context(), idTokenKey, rawIDToken)
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	rec := httptest.NewRecorder()
+	setHandler.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	cookies := rec.Result().Cookies()
+	require.NotEmpty(t, cookies, "should have a session cookie")
+	return cookies
 }
 
 // mockIdentityStore is a minimal mock for testing OIDC handlers that don't hit the store.

--- a/auth/logout_test.go
+++ b/auth/logout_test.go
@@ -1,0 +1,133 @@
+package auth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLogoutHandler_DestroysSession(t *testing.T) {
+	sessionMgr := setupSessionManager(t)
+	tenantID := uuid.New()
+
+	authenticator := &OIDCAuthenticator{
+		issuerURL:          "https://example.com",
+		endSessionEndpoint: "",
+	}
+
+	handler := NewOIDCHandlerWithAuthenticator(
+		Config{PostLogoutRedirect: "/goodbye"},
+		authenticator,
+		sessionMgr,
+		&mockIdentityStore{},
+	)
+
+	cookies := withSessionClaims(t, sessionMgr, SessionClaims{
+		Authenticated:  true,
+		UserID:         uuid.New(),
+		ActiveTenantID: &tenantID,
+	})
+
+	chain := sessionMgr.LoadAndSave(http.HandlerFunc(handler.LogoutHandler))
+
+	req := httptest.NewRequest("POST", "/oidc/logout", nil)
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	rec := httptest.NewRecorder()
+	chain.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusSeeOther, rec.Code)
+	assert.Equal(t, "/goodbye", rec.Header().Get("Location"))
+}
+
+func TestLogoutHandler_RedirectsToProviderEndSession(t *testing.T) {
+	sessionMgr := setupSessionManager(t)
+	tenantID := uuid.New()
+
+	authenticator := &OIDCAuthenticator{
+		issuerURL:          "https://example.com",
+		endSessionEndpoint: "https://example.com/session/end",
+	}
+
+	handler := NewOIDCHandlerWithAuthenticator(
+		Config{PostLogoutRedirect: "/goodbye"},
+		authenticator,
+		sessionMgr,
+		&mockIdentityStore{},
+	)
+
+	cookies := withSessionClaims(t, sessionMgr, SessionClaims{
+		Authenticated:  true,
+		UserID:         uuid.New(),
+		ActiveTenantID: &tenantID,
+	})
+
+	chain := sessionMgr.LoadAndSave(http.HandlerFunc(handler.LogoutHandler))
+
+	req := httptest.NewRequest("POST", "/oidc/logout", nil)
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	rec := httptest.NewRecorder()
+	chain.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusSeeOther, rec.Code)
+	location := rec.Header().Get("Location")
+	assert.Contains(t, location, "https://example.com/session/end")
+	assert.Contains(t, location, "post_logout_redirect_uri=%2Fgoodbye")
+}
+
+func TestLogoutHandler_NoSessionStillSucceeds(t *testing.T) {
+	sessionMgr := setupSessionManager(t)
+
+	authenticator := &OIDCAuthenticator{
+		issuerURL:          "https://example.com",
+		endSessionEndpoint: "",
+	}
+
+	handler := NewOIDCHandlerWithAuthenticator(
+		Config{PostLogoutRedirect: "/"},
+		authenticator,
+		sessionMgr,
+		&mockIdentityStore{},
+	)
+
+	chain := sessionMgr.LoadAndSave(http.HandlerFunc(handler.LogoutHandler))
+
+	req := httptest.NewRequest("POST", "/oidc/logout", nil)
+	rec := httptest.NewRecorder()
+	chain.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusSeeOther, rec.Code)
+	assert.Equal(t, "/", rec.Header().Get("Location"))
+}
+
+func TestOIDCAuthenticator_EndSessionURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		endpoint string
+		want     string
+	}{
+		{"with endpoint", "https://id.example.com/end_session", "https://id.example.com/end_session"},
+		{"no endpoint", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			auth := &OIDCAuthenticator{
+				issuerURL:          "https://example.com",
+				endSessionEndpoint: tt.endpoint,
+			}
+			assert.Equal(t, tt.want, auth.EndSessionURL())
+		})
+	}
+}
+
+// mockIdentityStore is a minimal mock for testing OIDC handlers that don't hit the store.
+type mockIdentityStore struct {
+	IdentityStore
+}

--- a/auth/oidc.go
+++ b/auth/oidc.go
@@ -46,10 +46,11 @@ type OIDCProvider interface {
 // ID token verification, and UserInfo retrieval. It is used internally by
 // [OIDCHandler] but can also be used directly for custom authentication flows.
 type OIDCAuthenticator struct {
-	oauth2Config oauth2.Config
-	verifier     *oidc.IDTokenVerifier
-	provider     OIDCProvider
-	issuerURL    string
+	oauth2Config      oauth2.Config
+	verifier          *oidc.IDTokenVerifier
+	provider          OIDCProvider
+	issuerURL         string
+	endSessionEndpoint string
 }
 
 // NewOIDCAuthenticator creates a new OIDCAuthenticator by discovering the
@@ -71,7 +72,22 @@ func NewOIDCAuthenticator(cfg Config) (*OIDCAuthenticator, error) {
 		return nil, err
 	}
 
-	return NewOIDCAuthenticatorWithProvider(parsedCfg, provider)
+	// Discover end_session_endpoint from the provider's well-known configuration.
+	// This is optional per OIDC spec — not all providers support RP-initiated logout.
+	var endSessionEndpoint string
+	var providerClaims struct {
+		EndSessionEndpoint string `json:"end_session_endpoint"`
+	}
+	if err := provider.Claims(&providerClaims); err == nil {
+		endSessionEndpoint = providerClaims.EndSessionEndpoint
+	}
+
+	auth, err := NewOIDCAuthenticatorWithProvider(parsedCfg, provider)
+	if err != nil {
+		return nil, err
+	}
+	auth.endSessionEndpoint = endSessionEndpoint
+	return auth, nil
 }
 
 // NewOIDCAuthenticatorWithProvider creates a new OIDCAuthenticator with a
@@ -89,17 +105,25 @@ func NewOIDCAuthenticatorWithProvider(cfg Config, provider OIDCProvider) (*OIDCA
 		Scopes:       []string{oidc.ScopeOpenID, "profile", "email"},
 	}
 
-	return &OIDCAuthenticator{
+	auth := &OIDCAuthenticator{
 		oauth2Config: oauth2Config,
 		verifier:     provider.Verifier(&oidc.Config{ClientID: cfg.ClientID}),
 		provider:     provider,
 		issuerURL:    cfg.IssuerURL,
-	}, nil
+	}
+
+	return auth, nil
 }
 
 // GetIssuer returns the OIDC issuer URL.
 func (o *OIDCAuthenticator) GetIssuer() string {
 	return o.issuerURL
+}
+
+// EndSessionURL returns the provider's end_session_endpoint URL, or empty
+// string if the provider does not support RP-initiated logout.
+func (o *OIDCAuthenticator) EndSessionURL() string {
+	return o.endSessionEndpoint
 }
 
 // Exchange exchanges an OIDC authorization code for OAuth2 tokens.

--- a/auth/types.go
+++ b/auth/types.go
@@ -70,6 +70,10 @@ const (
 	DefaultTenantsPath = "/tenants"
 	// DefaultTenantSelectPath is the default API path for selecting an active tenant.
 	DefaultTenantSelectPath = "/tenant/select"
+	// DefaultLogoutPath is the default path for the OIDC logout endpoint.
+	DefaultLogoutPath = "/oidc/logout"
+	// DefaultPostLogoutRedirect is the default URL to redirect to after logout.
+	DefaultPostLogoutRedirect = "/"
 	// DefaultStateCookieName is the default cookie name for the OIDC state parameter.
 	DefaultStateCookieName = "oidc_state"
 	// DefaultCookieMaxAgeSecond is the default max age (in seconds) for the state cookie.


### PR DESCRIPTION
## Summary

Adds a proper OIDC logout endpoint that was missing from the OIDC auth handler. The password handler already had a `LogoutHandler` that calls `session.Destroy()`, but OIDC users had no way to log out.

## Changes

- **LogoutHandler** — Destroys the local session via `session.Destroy()`, then redirects
- **RP-Initiated Logout** — Discovers the provider's `end_session_endpoint` from well-known config and redirects there with `post_logout_redirect_uri` when available
- **Config** — New `LogoutPath` (default `/oidc/logout`) and `PostLogoutRedirect` (default `/`) fields
- **Route** — `POST /oidc/logout` registered in `OIDCHandler.RegisterRoutes`
- **Tests** — Unit tests for session destruction, provider redirect, and no-session edge case

## Behavior

1. `session.Destroy()` is called to invalidate the local session immediately
2. If the provider exposes `end_session_endpoint`, redirect there with `post_logout_redirect_uri`
3. Otherwise, redirect to `Config.PostLogoutRedirect` (defaults to `/`)

## Related

- Gotchi task #19: Add OIDC logout endpoint
- CertCanary PR #9 security review flagged missing logout