### PR TITLE
feat(testutil): add integration test utilities for PostgreSQL

### DIFF
--- a/testutil/postgres.go
+++ b/testutil/postgres.go
@@ -1,0 +1,190 @@
+// Package testutil provides utilities for integration testing against a
+// real PostgreSQL database running in a Docker container.
+//
+// # Basic Usage (with migrations)
+//
+//	func TestMain(m *testing.M) {
+//	    testDB := testutil.SetupTestDB(m,
+//	        testutil.WithMigrations(
+//	            db.MigrationSource{FS: migrations.Core(), Dir: "."},
+//	            db.MigrationSource{FS: migrations.Auth(), Dir: "."},
+//	        ),
+//	    )
+//	    defer testDB.Close()
+//	    os.Exit(m.Run())
+//	}
+//
+// # With App-Specific Migrations
+//
+//	func TestMain(m *testing.M) {
+//	    testDB := testutil.SetupTestDB(m,
+//	        testutil.WithMigrations(
+//	            db.MigrationSource{FS: migrations.Core(), Dir: "."},
+//	            db.MigrationSource{FS: migrations.Auth(), Dir: "."},
+//	            db.MigrationSource{FS: myAppMigrations, Dir: "."},
+//	        ),
+//	    )
+//	    defer testDB.Close()
+//	    os.Exit(m.Run())
+//	}
+package testutil
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	dockertest "github.com/ory/dockertest/v4"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kusold/gotchi/db"
+)
+
+// TestDB holds the resources for an integration test database.
+type TestDB struct {
+	Pool        *pgxpool.Pool
+	DatabaseURL string
+	closer      func()
+}
+
+// Close releases all Docker and database resources.
+func (tdb *TestDB) Close() {
+	if tdb.closer != nil {
+		tdb.closer()
+	}
+}
+
+// SetupOption configures [SetupTestDB] behavior.
+type SetupOption func(*setupConfig)
+
+type setupConfig struct {
+	migrationSources []db.MigrationSource
+}
+
+// WithMigrations registers migration sources to apply after the test database
+// is created. Migrations are applied in the order provided. If no migration
+// sources are provided, the database is created but no schema is applied.
+func WithMigrations(sources ...db.MigrationSource) SetupOption {
+	return func(cfg *setupConfig) {
+		cfg.migrationSources = append(cfg.migrationSources, sources...)
+	}
+}
+
+// SetupTestDB starts a PostgreSQL container using dockertest and runs any
+// registered migrations. It returns a TestDB that must be closed with Close()
+// when the test is done.
+//
+// Use [WithMigrations] to register migration sources:
+//
+//	testDB := testutil.SetupTestDB(m,
+//	    testutil.WithMigrations(
+//	        db.MigrationSource{FS: migrations.Core(), Dir: "."},
+//	    ),
+//	)
+func SetupTestDB(m *testing.M, opts ...SetupOption) *TestDB {
+	var cfg setupConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	ctx := context.Background()
+
+	// Connect to Docker using v4 API
+	pool, err := dockertest.NewPool(ctx, "",
+		dockertest.WithMaxWait(2*time.Minute),
+	)
+	if err != nil {
+		fmt.Printf("Could not connect to docker: %s\n", err)
+		return nil
+	}
+
+	// Start PostgreSQL container using v4 functional options
+	resource, err := pool.Run(ctx, "postgres",
+		dockertest.WithTag("18-alpine"),
+		dockertest.WithEnv([]string{
+			"POSTGRES_PASSWORD=secret",
+			"POSTGRES_DB=testdb",
+		}),
+	)
+	if err != nil {
+		fmt.Printf("Could not start postgres container: %s\n", err)
+		pool.Close(ctx)
+		return nil
+	}
+
+	// Get host:port
+	hostPort := resource.GetHostPort("5432/tcp")
+	databaseURL := fmt.Sprintf("postgres://postgres:secret@%s/testdb?sslmode=disable", hostPort)
+
+	// Wait for PostgreSQL to be ready - v4 API requires context and timeout
+	var dbPool *pgxpool.Pool
+	if err = pool.Retry(ctx, 30*time.Second, func() error {
+		var err error
+		dbPool, err = pgxpool.New(ctx, databaseURL)
+		if err != nil {
+			return err
+		}
+		return dbPool.Ping(ctx)
+	}); err != nil {
+		fmt.Printf("Could not connect to postgres: %s\n", err)
+		pool.Close(ctx)
+		return nil
+	}
+
+	// Run migrations (no-op if no sources configured)
+	if err := runMigrations(ctx, databaseURL, cfg.migrationSources); err != nil {
+		fmt.Printf("Could not run migrations: %s\n", err)
+		dbPool.Close()
+		pool.Close(ctx)
+		return nil
+	}
+
+	return &TestDB{
+		Pool:        dbPool,
+		DatabaseURL: databaseURL,
+		closer: func() {
+			if dbPool != nil {
+				dbPool.Close()
+			}
+			pool.Close(ctx)
+		},
+	}
+}
+
+// runMigrations connects to the database and runs the provided migration sources.
+// If sources is empty, it returns nil immediately.
+func runMigrations(ctx context.Context, databaseURL string, sources []db.MigrationSource) error {
+	if len(sources) == 0 {
+		return nil
+	}
+
+	mgr := db.NewManager(db.Config{
+		DatabaseURL: databaseURL,
+	})
+	for _, src := range sources {
+		mgr.AddMigrationSource(src)
+	}
+
+	if err := mgr.Connect(ctx); err != nil {
+		return fmt.Errorf("could not connect: %w", err)
+	}
+
+	if err := mgr.RunMigrations(ctx); err != nil {
+		return fmt.Errorf("could not run migrations: %w", err)
+	}
+
+	return nil
+}
+
+// RequireTestDB is like SetupTestDB but fails the test immediately if setup fails.
+// Use this in TestMain when you want the test to fail fast on setup errors.
+func RequireTestDB(tb testing.TB, m *testing.M, opts ...SetupOption) *TestDB {
+	testDB := SetupTestDB(m, opts...)
+	if testDB == nil {
+		tb.Fatal("Failed to setup test database")
+	}
+	require.NotNil(tb, testDB.Pool, "test database pool should not be nil")
+	return testDB
+}

--- a/testutil/postgres.go
+++ b/testutil/postgres.go
@@ -32,12 +32,12 @@ package testutil
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	dockertest "github.com/ory/dockertest/v4"
-	"github.com/stretchr/testify/require"
 
 	"github.com/kusold/gotchi/db"
 )
@@ -100,7 +100,9 @@ func SetupTestDB(m *testing.M, opts ...SetupOption) *TestDB {
 		return nil
 	}
 
-	// Start PostgreSQL container using v4 functional options
+	// Start PostgreSQL container using v4 functional options.
+	// Credentials are intentionally trivial — the container is ephemeral and
+	// only accessible from the local host.
 	resource, err := pool.Run(ctx, "postgres",
 		dockertest.WithTag("18-alpine"),
 		dockertest.WithEnv([]string{
@@ -121,6 +123,9 @@ func SetupTestDB(m *testing.M, opts ...SetupOption) *TestDB {
 	// Wait for PostgreSQL to be ready - v4 API requires context and timeout
 	var dbPool *pgxpool.Pool
 	if err = pool.Retry(ctx, 30*time.Second, func() error {
+		if dbPool != nil {
+			dbPool.Close()
+		}
 		var err error
 		dbPool, err = pgxpool.New(ctx, databaseURL)
 		if err != nil {
@@ -170,6 +175,7 @@ func runMigrations(ctx context.Context, databaseURL string, sources []db.Migrati
 	if err := mgr.Connect(ctx); err != nil {
 		return fmt.Errorf("could not connect: %w", err)
 	}
+	defer mgr.Close()
 
 	if err := mgr.RunMigrations(ctx); err != nil {
 		return fmt.Errorf("could not run migrations: %w", err)
@@ -178,13 +184,13 @@ func runMigrations(ctx context.Context, databaseURL string, sources []db.Migrati
 	return nil
 }
 
-// RequireTestDB is like SetupTestDB but fails the test immediately if setup fails.
+// RequireTestDB is like SetupTestDB but terminates the process if setup fails.
 // Use this in TestMain when you want the test to fail fast on setup errors.
-func RequireTestDB(tb testing.TB, m *testing.M, opts ...SetupOption) *TestDB {
+func RequireTestDB(m *testing.M, opts ...SetupOption) *TestDB {
 	testDB := SetupTestDB(m, opts...)
-	if testDB == nil {
-		tb.Fatal("Failed to setup test database")
+	if testDB == nil || testDB.Pool == nil {
+		fmt.Println("Failed to setup test database")
+		os.Exit(1)
 	}
-	require.NotNil(tb, testDB.Pool, "test database pool should not be nil")
 	return testDB
 }

--- a/testutil/postgres.go
+++ b/testutil/postgres.go
@@ -1,43 +1,42 @@
 // Package testutil provides utilities for integration testing against a
 // real PostgreSQL database running in a Docker container.
 //
-// # Basic Usage (with migrations)
+// # Basic Usage
+//
+// Use [SetupTestDB] in TestMain when you want to handle setup errors yourself:
 //
 //	func TestMain(m *testing.M) {
+//	    if testing.Short() {
+//	        os.Exit(m.Run())
+//	    }
 //	    testDB := testutil.SetupTestDB(m,
 //	        testutil.WithMigrations(
 //	            db.MigrationSource{FS: migrations.Core(), Dir: "."},
 //	            db.MigrationSource{FS: migrations.Auth(), Dir: "."},
 //	        ),
 //	    )
-//	    defer testDB.Close()
-//	    os.Exit(m.Run())
+//	    if testDB == nil {
+//	        fmt.Println("Failed to setup test database")
+//	        os.Exit(1)
+//	    }
+//	    code := m.Run()
+//	    testDB.Close()
+//	    os.Exit(code)
 //	}
 //
-// # With App-Specific Migrations
-//
-//	func TestMain(m *testing.M) {
-//	    testDB := testutil.SetupTestDB(m,
-//	        testutil.WithMigrations(
-//	            db.MigrationSource{FS: migrations.Core(), Dir: "."},
-//	            db.MigrationSource{FS: migrations.Auth(), Dir: "."},
-//	            db.MigrationSource{FS: myAppMigrations, Dir: "."},
-//	        ),
-//	    )
-//	    defer testDB.Close()
-//	    os.Exit(m.Run())
-//	}
+// Use [RequireTestDB] in test functions where you have a testing.TB to get
+// a proper test failure with t.Fatal on error.
 package testutil
 
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	dockertest "github.com/ory/dockertest/v4"
+	"github.com/stretchr/testify/require"
 
 	"github.com/kusold/gotchi/db"
 )
@@ -74,7 +73,8 @@ func WithMigrations(sources ...db.MigrationSource) SetupOption {
 
 // SetupTestDB starts a PostgreSQL container using dockertest and runs any
 // registered migrations. It returns a TestDB that must be closed with Close()
-// when the test is done.
+// when the test is done. If the container cannot be started or migrations
+// fail, it returns nil. Use [RequireTestDB] to fail immediately on error.
 //
 // Use [WithMigrations] to register migration sources:
 //
@@ -184,13 +184,12 @@ func runMigrations(ctx context.Context, databaseURL string, sources []db.Migrati
 	return nil
 }
 
-// RequireTestDB is like SetupTestDB but terminates the process if setup fails.
-// Use this in TestMain when you want the test to fail fast on setup errors.
-func RequireTestDB(m *testing.M, opts ...SetupOption) *TestDB {
+// RequireTestDB is like [SetupTestDB] but calls tb.Fatal if setup fails.
+func RequireTestDB(tb testing.TB, m *testing.M, opts ...SetupOption) *TestDB {
 	testDB := SetupTestDB(m, opts...)
-	if testDB == nil || testDB.Pool == nil {
-		fmt.Println("Failed to setup test database")
-		os.Exit(1)
+	if testDB == nil {
+		tb.Fatal("Failed to setup test database")
 	}
+	require.NotNil(tb, testDB.Pool, "test database pool should not be nil")
 	return testDB
 }

--- a/testutil/postgres_test.go
+++ b/testutil/postgres_test.go
@@ -1,0 +1,95 @@
+package testutil
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kusold/gotchi/db"
+	"github.com/kusold/gotchi/migrations"
+)
+
+var testDB *TestDB
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	if !testing.Short() {
+		testDB = SetupTestDB(m,
+			WithMigrations(
+				db.MigrationSource{FS: migrations.Core(), Dir: "."},
+				db.MigrationSource{FS: migrations.Auth(), Dir: "."},
+			),
+		)
+		if testDB == nil {
+			fmt.Println("Integration tests require a container runtime")
+			os.Exit(1)
+		}
+	}
+
+	code := m.Run()
+	if testDB != nil {
+		testDB.Close()
+	}
+	os.Exit(code)
+}
+
+func skipIfShort(t *testing.T) {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+}
+
+func TestSetupTestDB_WithMigrations(t *testing.T) {
+	skipIfShort(t)
+	require.NotNil(t, testDB)
+	require.NotNil(t, testDB.Pool)
+
+	// Verify core schema was applied: sessions table should exist
+	var exists bool
+	err := testDB.Pool.QueryRow(t.Context(),
+		"SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = 'sessions')").Scan(&exists)
+	require.NoError(t, err)
+	assert.True(t, exists, "sessions table should exist after core migrations")
+}
+
+func TestSetupTestDB_NoMigrations(t *testing.T) {
+	skipIfShort(t)
+
+	// SetupTestDB with no migration sources should create a working database
+	// but with no application schema.
+	bareDB := SetupTestDB(nil)
+	if bareDB == nil {
+		t.Fatal("Failed to setup bare test database")
+	}
+	defer bareDB.Close()
+
+	// Verify sessions table does NOT exist (no migrations ran)
+	var exists bool
+	err := bareDB.Pool.QueryRow(t.Context(),
+		"SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = 'sessions')").Scan(&exists)
+	require.NoError(t, err)
+	assert.False(t, exists, "sessions table should not exist when no migrations are configured")
+
+	// But basic queries should work
+	var result int
+	err = bareDB.Pool.QueryRow(t.Context(), "SELECT 1").Scan(&result)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result)
+}
+
+func TestWithMigrations_AppendsSources(t *testing.T) {
+	var cfg setupConfig
+	WithMigrations(
+		db.MigrationSource{Dir: "first"},
+		db.MigrationSource{Dir: "second"},
+	)(&cfg)
+
+	require.Len(t, cfg.migrationSources, 2)
+	assert.Equal(t, "first", cfg.migrationSources[0].Dir)
+	assert.Equal(t, "second", cfg.migrationSources[1].Dir)
+}

--- a/testutil/postgres_test.go
+++ b/testutil/postgres_test.go
@@ -1,11 +1,14 @@
 package testutil
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -17,23 +20,23 @@ var testDB *TestDB
 
 func TestMain(m *testing.M) {
 	flag.Parse()
-	if !testing.Short() {
-		testDB = SetupTestDB(m,
-			WithMigrations(
-				db.MigrationSource{FS: migrations.Core(), Dir: "."},
-				db.MigrationSource{FS: migrations.Auth(), Dir: "."},
-			),
-		)
-		if testDB == nil {
-			fmt.Println("Integration tests require a container runtime, skipping")
-			os.Exit(0)
-		}
+	if testing.Short() {
+		os.Exit(m.Run())
+	}
+
+	testDB = SetupTestDB(m,
+		WithMigrations(
+			db.MigrationSource{FS: migrations.Core(), Dir: "."},
+			db.MigrationSource{FS: migrations.Auth(), Dir: "."},
+		),
+	)
+	if testDB == nil {
+		fmt.Println("Failed to setup test database")
+		os.Exit(1)
 	}
 
 	code := m.Run()
-	if testDB != nil {
-		testDB.Close()
-	}
+	testDB.Close()
 	os.Exit(code)
 }
 
@@ -59,25 +62,36 @@ func TestSetupTestDB_WithMigrations(t *testing.T) {
 
 func TestSetupTestDB_NoMigrations(t *testing.T) {
 	skipIfShort(t)
+	require.NotNil(t, testDB)
 
-	// SetupTestDB with no migration sources should create a working database
-	// but with no application schema.
-	bareDB := SetupTestDB(nil)
-	if bareDB == nil {
-		t.Fatal("Failed to setup bare test database")
-	}
-	defer bareDB.Close()
+	// Create a fresh database on the existing container to verify that no
+	// schema is applied when no migration sources are configured. This avoids
+	// spinning up a second container which may share state in some CI
+	// environments.
+	const dbName = "test_no_migrations"
+	_, err := testDB.Pool.Exec(t.Context(),
+		fmt.Sprintf("CREATE DATABASE %s", dbName))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		testDB.Pool.Exec(context.Background(),
+			fmt.Sprintf("DROP DATABASE IF EXISTS %s", dbName))
+	})
+
+	bareURL := strings.Replace(testDB.DatabaseURL, "/testdb", "/"+dbName, 1)
+	barePool, err := pgxpool.New(t.Context(), bareURL)
+	require.NoError(t, err)
+	defer barePool.Close()
 
 	// Verify sessions table does NOT exist (no migrations ran)
 	var exists bool
-	err := bareDB.Pool.QueryRow(t.Context(),
+	err = barePool.QueryRow(t.Context(),
 		"SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = 'sessions')").Scan(&exists)
 	require.NoError(t, err)
 	assert.False(t, exists, "sessions table should not exist when no migrations are configured")
 
 	// But basic queries should work
 	var result int
-	err = bareDB.Pool.QueryRow(t.Context(), "SELECT 1").Scan(&result)
+	err = barePool.QueryRow(t.Context(), "SELECT 1").Scan(&result)
 	require.NoError(t, err)
 	assert.Equal(t, 1, result)
 }

--- a/testutil/postgres_test.go
+++ b/testutil/postgres_test.go
@@ -25,8 +25,8 @@ func TestMain(m *testing.M) {
 			),
 		)
 		if testDB == nil {
-			fmt.Println("Integration tests require a container runtime")
-			os.Exit(1)
+			fmt.Println("Integration tests require a container runtime, skipping")
+			os.Exit(0)
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Adds `testutil` package with `SetupTestDB` and `RequireTestDB` helpers that spin up a PostgreSQL container via dockertest
- Supports configurable migration sources via `WithMigrations` functional option — tests can mix core, auth, password, or app-specific schemas
- Gracefully returns `nil` when no container runtime is available, so CI environments without Docker can skip integration tests

## Test plan
- [ ] Run `go test ./testutil/ -v` with a container runtime available — both tests should pass
- [ ] Run `go test ./testutil/ -v -short` — tests should be skipped
- [ ] Import `testutil` from another package's `TestMain` and verify the pool/migrations work as expected