### PR TITLE
Fix Application.Run context cancellation

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -40,6 +40,7 @@
 // options are optional and have sensible defaults:
 //
 //   - [WithPort] — HTTP server port (default "3000")
+//   - [WithShutdownTimeout] — graceful HTTP shutdown timeout (default 5s)
 //   - [WithAuth] — enables OIDC authentication (auto-enables sessions)
 //   - [WithSessions] — explicit session configuration
 //   - [WithOTEL] — OpenTelemetry tracing and metrics
@@ -97,7 +98,10 @@ type Clock interface {
 // realClock is the production Clock implementation that delegates to time.Now.
 type realClock struct{}
 
-const defaultOTELShutdownTimeout = 5 * time.Second
+const (
+	defaultOTELShutdownTimeout = 5 * time.Second
+	defaultShutdownTimeout     = 5 * time.Second
+)
 
 // Now returns the current local time.
 func (realClock) Now() time.Time {
@@ -170,6 +174,11 @@ type Application struct {
 	otelShutdown func(context.Context) error
 }
 
+type httpServer interface {
+	ListenAndServe() error
+	Shutdown(context.Context) error
+}
+
 // New creates an Application from the supplied options.
 // At minimum, WithDatabase or WithDatabaseConfig must be provided.
 func New(opts ...Option) (*Application, error) {
@@ -210,7 +219,9 @@ func (a *Application) Dependencies() Dependencies {
 }
 
 // Run initializes all configured subsystems and starts the HTTP server.
-// It blocks until the server exits or ctx is cancelled.
+// It blocks until the server exits or ctx is cancelled. When ctx is cancelled,
+// Run gracefully shuts down the HTTP server using the configured shutdown
+// timeout and returns nil if shutdown succeeds.
 func (a *Application) Run(ctx context.Context) error {
 	cfg := &a.config
 
@@ -352,7 +363,35 @@ func (a *Application) Run(ctx context.Context) error {
 		}
 	}
 
-	return http.ListenAndServe(fmt.Sprintf(":%s", cfg.port), a.router)
+	server := &http.Server{
+		Addr:    fmt.Sprintf(":%s", cfg.port),
+		Handler: a.router,
+	}
+
+	return runHTTPServer(ctx, server, cfg.shutdownTimeout)
+}
+
+func runHTTPServer(ctx context.Context, server httpServer, shutdownTimeout time.Duration) error {
+	errCh := make(chan error, 1)
+	go func() {
+		if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errCh <- err
+			return
+		}
+		errCh <- nil
+	}()
+
+	select {
+	case err := <-errCh:
+		return err
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+		defer cancel()
+		if err := server.Shutdown(shutdownCtx); err != nil {
+			return err
+		}
+		return <-errCh
+	}
 }
 
 // setupMiddleware applies all configured middleware to the router.

--- a/app/application_test.go
+++ b/app/application_test.go
@@ -1,9 +1,12 @@
 package app
 
 import (
+	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/cors"
@@ -81,6 +84,100 @@ func TestApplicationClose(t *testing.T) {
 		err = app.Close()
 		assert.NoError(t, err)
 	})
+}
+
+func TestRunHTTPServer(t *testing.T) {
+	t.Run("context cancellation shuts down the server", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		server := newFakeHTTPServer()
+
+		done := make(chan error, 1)
+		go func() {
+			done <- runHTTPServer(ctx, server, 25*time.Millisecond)
+		}()
+
+		<-server.listenStarted
+		cancel()
+
+		require.NoError(t, <-done)
+
+		shutdownCtx := <-server.shutdownCtx
+		deadline, ok := shutdownCtx.Deadline()
+		require.True(t, ok)
+		assert.WithinDuration(t, time.Now().Add(25*time.Millisecond), deadline, 20*time.Millisecond)
+	})
+
+	t.Run("returns shutdown error", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		server := newFakeHTTPServer()
+		server.shutdownErr = errors.New("shutdown failed")
+
+		done := make(chan error, 1)
+		go func() {
+			done <- runHTTPServer(ctx, server, time.Second)
+		}()
+
+		<-server.listenStarted
+		cancel()
+
+		require.EqualError(t, <-done, "shutdown failed")
+	})
+
+	t.Run("returns server error", func(t *testing.T) {
+		server := newFakeHTTPServer()
+		wantErr := errors.New("listen failed")
+
+		done := make(chan error, 1)
+		go func() {
+			done <- runHTTPServer(context.Background(), server, time.Second)
+		}()
+
+		<-server.listenStarted
+		server.serveErr <- wantErr
+
+		require.ErrorIs(t, <-done, wantErr)
+		assert.Empty(t, server.shutdownCtx)
+	})
+
+	t.Run("treats ErrServerClosed as nil", func(t *testing.T) {
+		server := newFakeHTTPServer()
+
+		done := make(chan error, 1)
+		go func() {
+			done <- runHTTPServer(context.Background(), server, time.Second)
+		}()
+
+		<-server.listenStarted
+		server.serveErr <- http.ErrServerClosed
+
+		require.NoError(t, <-done)
+	})
+}
+
+type fakeHTTPServer struct {
+	listenStarted chan struct{}
+	serveErr      chan error
+	shutdownCtx   chan context.Context
+	shutdownErr   error
+}
+
+func newFakeHTTPServer() *fakeHTTPServer {
+	return &fakeHTTPServer{
+		listenStarted: make(chan struct{}),
+		serveErr:      make(chan error, 1),
+		shutdownCtx:   make(chan context.Context, 1),
+	}
+}
+
+func (s *fakeHTTPServer) ListenAndServe() error {
+	close(s.listenStarted)
+	return <-s.serveErr
+}
+
+func (s *fakeHTTPServer) Shutdown(ctx context.Context) error {
+	s.shutdownCtx <- ctx
+	s.serveErr <- http.ErrServerClosed
+	return s.shutdownErr
 }
 
 func TestRealClock(t *testing.T) {

--- a/app/config_test.go
+++ b/app/config_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httptest"
 	"testing"
 	"testing/fstest"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/cors"
@@ -35,6 +36,12 @@ func TestBuilderDefaults(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotNil(t, app.config.clock)
 		assert.NotNil(t, app.config.logger)
+	})
+
+	t.Run("sets default shutdown timeout", func(t *testing.T) {
+		app, err := New(testOpts()...)
+		require.NoError(t, err)
+		assert.Equal(t, defaultShutdownTimeout, app.config.shutdownTimeout)
 	})
 }
 
@@ -101,6 +108,26 @@ func TestWithDatabaseConfig(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "postgres://example", app.config.dbConfig.DatabaseURL)
 		assert.True(t, app.config.dbConfig.EnableSlogTracing)
+	})
+}
+
+func TestWithShutdownTimeout(t *testing.T) {
+	t.Run("preserves provided timeout", func(t *testing.T) {
+		app, err := New(
+			WithDatabase("postgres://example"),
+			WithShutdownTimeout(30*time.Second),
+		)
+		require.NoError(t, err)
+		assert.Equal(t, 30*time.Second, app.config.shutdownTimeout)
+	})
+
+	t.Run("rejects non-positive timeout", func(t *testing.T) {
+		_, err := New(
+			WithDatabase("postgres://example"),
+			WithShutdownTimeout(0),
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "shutdown timeout must be positive")
 	})
 }
 

--- a/app/option.go
+++ b/app/option.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"time"
 
 	"github.com/go-chi/cors"
 	"github.com/kusold/gotchi/auth"
@@ -44,7 +45,8 @@ func corsDefaults(first string, rest ...string) CORSConfig {
 // builder accumulates configuration from options before constructing the Application.
 type builder struct {
 	// server
-	port string
+	port            string
+	shutdownTimeout time.Duration
 
 	// database (required)
 	dbConfig *db.Config
@@ -104,6 +106,9 @@ func (b *builder) applyDefaults() {
 	if b.port == "" {
 		b.port = "3000"
 	}
+	if b.shutdownTimeout == 0 {
+		b.shutdownTimeout = defaultShutdownTimeout
+	}
 	if b.authConfig != nil {
 		defaults := b.authConfig.WithDefaults()
 		b.authConfig = &defaults
@@ -150,6 +155,18 @@ func WithDatabaseConfig(cfg db.Config) Option {
 func WithPort(port string) Option {
 	return func(b *builder) error {
 		b.port = port
+		return nil
+	}
+}
+
+// WithShutdownTimeout sets the maximum time Run waits for in-flight HTTP
+// requests to finish after ctx is cancelled. Defaults to 5 seconds.
+func WithShutdownTimeout(timeout time.Duration) Option {
+	return func(b *builder) error {
+		if timeout <= 0 {
+			return fmt.Errorf("shutdown timeout must be positive")
+		}
+		b.shutdownTimeout = timeout
 		return nil
 	}
 }


### PR DESCRIPTION
Fixes issue #61 by making Application.Run honor context cancellation via an internal http.Server and configurable graceful shutdown timeout.\n\nChanges:\n- use http.Server in Run and shutdown on ctx cancellation\n- add WithShutdownTimeout with a 5s default\n- handle http.ErrServerClosed intentionally\n- add focused tests for cancellation and shutdown behavior