### PR TITLE
Fix password reset token consumption and expiry

### DIFF
--- a/auth/password/config_test.go
+++ b/auth/password/config_test.go
@@ -63,6 +63,13 @@ func TestTokenConfig_Defaults(t *testing.T) {
 	assert.Equal(t, 32, cfg.TokenLength)
 }
 
+func TestTokenConfig_WithDefaults_PreservesCustomResetExpiry(t *testing.T) {
+	cfg := TokenConfig{ResetTokenExpiry: 30 * time.Minute}.withDefaults()
+	assert.Equal(t, 30*time.Minute, cfg.ResetTokenExpiry)
+	assert.Equal(t, 24*time.Hour, cfg.VerificationTokenExpiry)
+	assert.Equal(t, 32, cfg.TokenLength)
+}
+
 func TestPasswordPolicy_Defaults(t *testing.T) {
 	cfg := PasswordPolicy{}.withDefaults()
 	assert.Equal(t, 8, cfg.MinLength)

--- a/auth/password/store.go
+++ b/auth/password/store.go
@@ -488,7 +488,15 @@ func (s *PasswordIdentityStore) InitiatePasswordReset(ctx context.Context, email
 func (s *PasswordIdentityStore) CompletePasswordReset(ctx context.Context, token, newPassword string) error {
 	tokenHash := sha256Sum(token)
 
-	userID, err := s.queries.ConsumeAuthToken(ctx, db.ConsumeAuthTokenParams{
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	txQueries := s.queries.WithTx(tx)
+
+	userID, err := txQueries.ConsumeAuthToken(ctx, db.ConsumeAuthTokenParams{
 		TokenHash: tokenHash,
 		TokenType: "password_reset",
 	})
@@ -500,7 +508,7 @@ func (s *PasswordIdentityStore) CompletePasswordReset(ctx context.Context, token
 	}
 
 	// Look up user to provide context words (email, username) for policy validation.
-	user, err := s.queries.GetUserByID(ctx, userID)
+	user, err := txQueries.GetUserByID(ctx, userID)
 	if err != nil {
 		return fmt.Errorf("failed to fetch user: %w", err)
 	}
@@ -521,12 +529,16 @@ func (s *PasswordIdentityStore) CompletePasswordReset(ctx context.Context, token
 		return fmt.Errorf("failed to hash password: %w", err)
 	}
 
-	err = s.queries.UpdatePasswordHash(ctx, db.UpdatePasswordHashParams{
+	err = txQueries.UpdatePasswordHash(ctx, db.UpdatePasswordHashParams{
 		UserID:       userID,
 		PasswordHash: hash,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to update password: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("failed to commit password reset: %w", err)
 	}
 
 	s.logger.Info("password reset completed", "user_id", userID)

--- a/auth/password/store_integration_test.go
+++ b/auth/password/store_integration_test.go
@@ -50,6 +50,10 @@ func requireIntegrationDB(t *testing.T) *testutil.TestDB {
 }
 
 func newTestPasswordStore(t *testing.T) (*PasswordIdentityStore, *auth.PostgresIdentityStore) {
+	return newTestPasswordStoreWithConfig(t, nil)
+}
+
+func newTestPasswordStoreWithConfig(t *testing.T, configure func(*PasswordConfig)) (*PasswordIdentityStore, *auth.PostgresIdentityStore) {
 	t.Helper()
 	db := requireIntegrationDB(t)
 
@@ -70,6 +74,9 @@ func newTestPasswordStore(t *testing.T) (*PasswordIdentityStore, *auth.PostgresI
 			MaxAttempts: 3,
 			Window:      15 * time.Minute,
 		},
+	}
+	if configure != nil {
+		configure(&cfg)
 	}
 
 	store, err := NewPasswordIdentityStore(db.Pool, inner, cfg, nil)
@@ -299,6 +306,10 @@ func TestPasswordReset_FullFlow(t *testing.T) {
 	// New password should work
 	_, err = store.Authenticate(ctx, email, newPassword, "127.0.0.1")
 	require.NoError(t, err)
+
+	err = store.CompletePasswordReset(ctx, token, "another-password-789")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrTokenInvalid))
 }
 
 func TestPasswordReset_InvalidToken(t *testing.T) {
@@ -308,6 +319,57 @@ func TestPasswordReset_InvalidToken(t *testing.T) {
 	err := store.CompletePasswordReset(ctx, "invalid-token", "new-password")
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, ErrTokenInvalid))
+}
+
+func TestPasswordReset_InvalidNewPasswordDoesNotConsumeToken(t *testing.T) {
+	ctx := context.Background()
+	store, _ := newTestPasswordStore(t)
+	email := uniqueEmail(t)
+
+	_, err := store.Register(ctx, RegisterRequest{
+		Email:    email,
+		Password: "old-password-123",
+	})
+	require.NoError(t, err)
+
+	token, err := store.InitiatePasswordReset(ctx, email)
+	require.NoError(t, err)
+	require.NotEmpty(t, token)
+
+	err = store.CompletePasswordReset(ctx, token, "short")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrPasswordPolicyViolation))
+
+	err = store.CompletePasswordReset(ctx, token, "new-password-456")
+	require.NoError(t, err)
+
+	_, err = store.Authenticate(ctx, email, "new-password-456", "127.0.0.1")
+	require.NoError(t, err)
+}
+
+func TestPasswordReset_ExpiredToken(t *testing.T) {
+	ctx := context.Background()
+	store, _ := newTestPasswordStoreWithConfig(t, func(cfg *PasswordConfig) {
+		cfg.Tokens.ResetTokenExpiry = -1 * time.Hour
+	})
+	email := uniqueEmail(t)
+
+	_, err := store.Register(ctx, RegisterRequest{
+		Email:    email,
+		Password: "old-password-123",
+	})
+	require.NoError(t, err)
+
+	token, err := store.InitiatePasswordReset(ctx, email)
+	require.NoError(t, err)
+	require.NotEmpty(t, token)
+
+	err = store.CompletePasswordReset(ctx, token, "new-password-456")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrTokenInvalid))
+
+	_, err = store.Authenticate(ctx, email, "old-password-123", "127.0.0.1")
+	require.NoError(t, err)
 }
 
 func TestPasswordReset_NonexistentEmail(t *testing.T) {


### PR DESCRIPTION
Fixes #58.

Password reset now consumes the token and updates the password in a single transaction, so validation or hashing failures no longer burn the token. I also added coverage for replay-after-success and expiry behavior, and kept the one-hour default for reset tokens configurable through `PasswordConfig.Tokens.ResetTokenExpiry`.